### PR TITLE
fix: fix typo and redefined error

### DIFF
--- a/docs/api/edgeApi.md
+++ b/docs/api/edgeApi.md
@@ -62,9 +62,9 @@ Logic Flow 的内置连线类型包括
 
 | 名称   | 类型   | 描述            |
 | :----- | :----- | :------- | :-------------- |
-| edgeConifg | EdgeConifg| 创建边的配置数据 |
+| edgeConfig | EdgeConfig| 创建边的配置数据 |
 ``` ts
-export type EdgeConifg = {
+export type EdgeConfig = {
   id?: string,
   type?: string,
   sourceNodeId: string,

--- a/docs/api/logicFlowApi.md
+++ b/docs/api/logicFlowApi.md
@@ -286,7 +286,7 @@ lf.deleteNode('id');
 创建连接两个节点的连线
 
 ```js
-createEdge(edgeConfig: EdgeConifg): void
+createEdge(edgeConfig: EdgeConfig): void
 ```
 
 **参数**

--- a/packages/core/src/LogicFlow.tsx
+++ b/packages/core/src/LogicFlow.tsx
@@ -35,7 +35,7 @@ import EventEmitter, { CallbackType } from './event/eventEmitter';
 import Keyboard from './keyboard';
 
 import {
-  EdgeConifg,
+  EdgeConfig,
   EdgeFilter,
   NodeConfig,
   NodeAttribute,
@@ -56,7 +56,7 @@ if (process.env.NODE_ENV === 'development') {
 
 type GraphConfigData = {
   nodes: NodeConfig[],
-  edges: EdgeConifg[],
+  edges: EdgeConfig[],
 };
 
 export default class LogicFlow {
@@ -348,7 +348,7 @@ export default class LogicFlow {
   // getModel = this.graphModel.getModel;
 
   /* 创建边 */
-  createEdge(edgeConfig: EdgeConifg): void {
+  createEdge(edgeConfig: EdgeConfig): void {
     this.graphModel.createEdge(edgeConfig);
   }
   /* 删除边 */

--- a/packages/core/src/model/GraphModel.ts
+++ b/packages/core/src/model/GraphModel.ts
@@ -9,7 +9,7 @@ import {
   ElementState, ModelType, EventType, ElementMaxzIndex, ElementType,
 } from '../constant/constant';
 import {
-  AdditionData, Point, NodeConfig, EdgeConifg, Style, PointTuple,
+  AdditionData, Point, NodeConfig, EdgeConfig, Style, PointTuple,
 } from '../type';
 import MenuModel from './MenuModel';
 import { updateTheme } from '../util/theme';
@@ -309,7 +309,7 @@ class GraphModel {
   }
 
   @action
-  createEdge(edgeConfig: EdgeConifg) {
+  createEdge(edgeConfig: EdgeConfig) {
     // 边的类型优先级：自定义>全局>默认
     let { type } = edgeConfig;
     if (!type) {

--- a/packages/core/src/type/index.ts
+++ b/packages/core/src/type/index.ts
@@ -72,17 +72,6 @@ export type MenuConfig = {
 
 export type AdditionData = Record<string, unknown>;
 
-export type EdgeConifg = {
-  id?: string,
-  type?: string,
-  // modelType: string, 待讨论，modelType不是默认了吗？用啥内置
-  sourceNodeId: string,
-  startPoint?: Point,
-  targetNodeId: string,
-  endPoint?: Point,
-  text?: string | TextConfig,
-  properties?: Record<string, unknown>;
-};
 // 边数据
 export type EdgeData = {
   id: string,


### PR DESCRIPTION
Spelling errors `EdgeConifg -> EdgeConfig` and **EdgeConfig** repeat definitions in type/index.ts