### PR TITLE
fix: typo

### DIFF
--- a/examples/src/pages/basic/edge/index.tsx
+++ b/examples/src/pages/basic/edge/index.tsx
@@ -107,7 +107,7 @@ export default function EdgeExample() {
     <>
       <ExampleHeader
         content="尝试为矩形和圆形手动添加连线"
-        githubPath="/basic/dege/index.tsx"
+        githubPath="/basic/edge/index.tsx"
       />
       <div>当前：{type}</div>
       <div>


### PR DESCRIPTION
docs: fix [边 Edge：尝试为矩形和圆形手动添加连线](http://logic-flow.org/guide/basic/edge.html#%E5%88%9B%E5%BB%BA%E8%BE%B9) 链接跳转404

![image](https://user-images.githubusercontent.com/12668546/124381939-887f2980-dcf7-11eb-9615-0f92dc7cef01.png)
