### PR TITLE
fix rules validate method param type

### DIFF
--- a/docs/article/article02.md
+++ b/docs/article/article02.md
@@ -95,7 +95,7 @@ class CnodeModel extends RectModel {
     const rules = super.getConnectedSourceRules();
     const gateWayOnlyAsTarget = {
       message: 'C节点下一个节点只能是A节点',
-      validate: (source: BaseNode, target: BaseNode) => {
+      validate: (source: BaseNodeModel, target: BaseNodeModel) => {
         let isValid = true;
         if (target.type !== 'a-node ') {
           isValid = false;

--- a/examples/src/pages/usage/approve/components/registerNode.ts
+++ b/examples/src/pages/usage/approve/components/registerNode.ts
@@ -1,5 +1,5 @@
 import LogicFlow, {
-  BaseNode,
+  BaseNodeModel,
   ConnectRule,
   CircleNodeModel,
   CircleNode,
@@ -18,7 +18,7 @@ export default function RegisteNode(lf: LogicFlow) {
       const rules = super.getConnectedTargetRules();
       const geteWayOnlyAsTarget = {
         message: '开始节点只能连出，不能连入！',
-        validate: (source:BaseNode, target:BaseNode) => {
+        validate: (source:BaseNodeModel, target:BaseNodeModel) => {
           let isValid = true;
           if (target) {
             isValid = false;
@@ -140,7 +140,7 @@ export default function RegisteNode(lf: LogicFlow) {
       const rules = super.getConnectedSourceRules();
       const geteWayOnlyAsTarget = {
         message: '结束节点只能连入，不能连出！',
-        validate: (source:BaseNode) => {
+        validate: (source:BaseNodeModel) => {
           let isValid = true;
           if (source) {
             isValid = false;


### PR DESCRIPTION
```javascript
validate: (source: BaseNodeModel, target: BaseNodeModel) => {
  console.log(source)
  console.log(source instanceof BaseNode)
  console.log(source instanceof BaseNodeModel)
  ...
}
```

![image](https://user-images.githubusercontent.com/25344334/125037346-99001d00-e0c6-11eb-95a5-b8ef621f4267.png)
`source`的类型应该是`BaseNodeModel`,而不是`BaseNode`