### PR TITLE
fix(connect validate):Compatible result two formats

### DIFF
--- a/packages/core/src/model/node/BaseNodeModel.ts
+++ b/packages/core/src/model/node/BaseNodeModel.ts
@@ -181,7 +181,7 @@ export default class BaseNodeModel implements IBaseModel {
   /**
    * 在连线的时候，是否允许这个节点为source节点，连线到target节点。
    */
-  isAllowConnectedAsSource(target: BaseNodeModel): ConnectRuleResult {
+  isAllowConnectedAsSource(target: BaseNodeModel): ConnectRuleResult | Boolean{
     const rules = !this.hasSetSourceRules
       ? this.getConnectedSourceRules()
       : this.sourceRules;
@@ -212,7 +212,7 @@ export default class BaseNodeModel implements IBaseModel {
    * 在连线的时候，是否允许这个节点未target节点
    */
 
-  isAllowConnectedAsTarget(source: BaseNodeModel): ConnectRuleResult {
+  isAllowConnectedAsTarget(source: BaseNodeModel): ConnectRuleResult | Boolean {
     const rules = !this.hasSetTargetRules
       ? this.getConnectedTargetRules()
       : this.targetRules;

--- a/packages/core/src/util/node.ts
+++ b/packages/core/src/util/node.ts
@@ -417,3 +417,17 @@ export const getSvgTextWidthHeight = ({ rows, rowsLength, fontSize }) => {
     height: rowsLength * (fontSize + 2) + fontSize / 4,
   };
 };
+
+
+/**
+ * @description 格式化连线校验信息
+ */
+ export const formateAnchorConnectValidateData= (data) =>{
+  if(typeof data !== 'object'){
+    return {
+      isAllPass:!!data,
+      msg:!!data?'':'不允许连接'
+    }
+  }
+  return data
+}

--- a/packages/core/src/view/Anchor.tsx
+++ b/packages/core/src/view/Anchor.tsx
@@ -1,6 +1,6 @@
 import { h, Component } from 'preact';
 import { createDrag } from '../util/drag';
-import { targetNodeInfo, distance } from '../util/node';
+import { formateAnchorConnectValidateData, targetNodeInfo, distance } from '../util/node';
 import Circle from './basic-shape/Circle';
 import Line from './basic-shape/Line';
 import { ElementState, EventType } from '../constant/constant';
@@ -93,8 +93,8 @@ class Anchor extends Component<IProps, IState> {
       if (!this.targetRuleResults.has(targetNode.id)) {
         const sourceRuleResult = nodeModel.isAllowConnectedAsSource(targetNode);
         const targetRuleResult = targetNode.isAllowConnectedAsTarget(nodeModel);
-        this.sourceRuleResults.set(targetNode.id, sourceRuleResult);
-        this.targetRuleResults.set(targetNode.id, targetRuleResult);
+        this.sourceRuleResults.set(targetNode.id, formateAnchorConnectValidateData(sourceRuleResult));
+        this.targetRuleResults.set(targetNode.id, formateAnchorConnectValidateData(targetRuleResult));
       }
       const { isAllPass: isSourcePass } = this.sourceRuleResults.get(targetNode.id);
       const { isAllPass: isTargetPass } = this.targetRuleResults.get(targetNode.id);


### PR DESCRIPTION
#287 Fix the question that the LoficFlow Base Node is connected alaways not allow when user set the result  from the custom`isAllowConnectedAsSource` or`isAllowConnectedAsTarget` to be boolean.