### PR TITLE
Update license to standard format

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "logicflow",
   "private": true,
   "description": "一款流程可视化的前端框架",
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
   "author": "LogicFlow-Team",
   "workspaces": [
     "packages/*",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,7 +3,7 @@
   "version": "0.6.16",
   "description": "LogicFlow core, to quickly build flowchart editor",
   "main": "dist/logic-flow.js",
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
   "types": "types/index.d.ts",
   "scripts": {
     "dev": "cross-env NODE_ENV=development MOCK_TYPE=mock webpack-dev-server --client-log-level warning --config scripts/webpack.config.dev.js",

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -5,7 +5,7 @@
   "main": "cjs/index.js",
   "module": "es/index.js",
   "types": "es/index.d.ts",
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
   "scripts": {
     "dev": "cross-env NODE_ENV=development MOCK_TYPE=mock webpack-dev-server --client-log-level warning --config scripts/webpack.config.dev.js",
     "test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
解决安装依赖时，控制台报许可证无效的问题。

> yarn
yarn install v1.22.10
warning package.json: License should be a valid SPDX license expression

from: https://spdx.org/licenses/