### PR TITLE
修复贝塞尔曲线连接的节点，在节点拖动时贝塞尔曲线路径被重置的问题

### DIFF
--- a/packages/core/src/model/edge/BezierEdgeModel.ts
+++ b/packages/core/src/model/edge/BezierEdgeModel.ts
@@ -61,7 +61,7 @@ export default class BezierEdgeModel extends BaseEdgeModel {
     const [
       start, sNext, ePre, end,
     ] = points;
-    return `M ${start.x} ${start.y} 
+    return `M ${start.x} ${start.y}
     C ${sNext.x} ${sNext.y},
     ${ePre.x} ${ePre.y},
     ${end.x} ${end.y}`;
@@ -91,15 +91,30 @@ export default class BezierEdgeModel extends BaseEdgeModel {
   }
 
   @action
+  updatePath() {
+    const start = {
+      x: this.startPoint.x,
+      y: this.startPoint.y,
+    };
+    const end = {
+      x: this.endPoint.x,
+      y: this.endPoint.y,
+    };
+    const [, sNext, ePre] = this.pointsList;
+    this.pointsList = [start, sNext, ePre, end];
+    this.path = this.getPath(this.pointsList);
+  }
+
+  @action
   updateStartPoint(anchor) {
     this.startPoint = anchor;
-    this.updatePoints();
+    this.updatePath();
   }
 
   @action
   updateEndPoint(anchor) {
     this.endPoint = anchor;
-    this.updatePoints();
+    this.updatePath();
   }
 
   @action


### PR DESCRIPTION
在使用贝塞尔曲线连接节点时，当拖动节点时，不再重新计算贝塞尔曲线的控制点，否则会导致贝塞尔曲线的路径被重置。
fixed #303 