### PR TITLE
fix(anchor validate):clear anchor validate cache

### DIFF
--- a/packages/core/src/view/Anchor.tsx
+++ b/packages/core/src/view/Anchor.tsx
@@ -167,6 +167,8 @@ class Anchor extends Component<IProps, IState> {
             targetAnchorId: info.anchor.id,
             endPoint: { x: info.anchor.x, y: info.anchor.y },
           });
+          // 清除掉缓存结果 fix:#320 因为创建连线之后，会影响校验结果变化，所以需要重新校验
+          this.targetRuleResults.clear();
         }
       } else {
         const nodeData = targetNode.getData();


### PR DESCRIPTION
#320 when edge add successfully,the node’s result of validate from  `isAllowConnectedAsSource ` or `isAllowConnectedAsTarget` may change.But the anchor has cached last result of validate,the  `isAllowConnectedAsSource ` or `isAllowConnectedAsTarget` will no be executed.

So when the edge add into scene,the anchor of edge should clear all cache about   `isAllowConnectedAsSource ` and `isAllowConnectedAsTarget` 