### PR TITLE
optimize:set the best anchor of target node when the user is dragging for creating edge between two nodes

### DIFF
--- a/packages/core/src/util/node.ts
+++ b/packages/core/src/util/node.ts
@@ -53,13 +53,31 @@ type AnchorInfo = {
   index: number,
   anchor: Point,
 };
-/* 手动连线时获取目标节点上，距离目标位置最近的锚点 */
+/**
+ * 手动连线时获取目标节点上，距离目标位置最近的锚点
+ *  @param  {Object} position 坐标信息
+ *  @param  {number} position.x 鼠标的横向坐标
+ *  @param  {number} position.y 鼠标的纵向坐标
+ *  @param  {number|null} position.sourceTargetX 连线源节点的锚点横坐标
+ *  @param  {number|null} position.sourceTargetY 连线源节点的锚点纵坐标
+ *  @param node
+ *  @returns
+ * */
+
 const getClosestAnchor = (position: Point, node: BaseNode): AnchorInfo => {
   const anchors = getAnchors(node);
+  const { sourceTargetX, sourceTargetY } = position;
+  let { x, y } = position;
+  if (!Number.isNaN(+sourceTargetX) && !Number.isNaN(+sourceTargetY)) {
+    // 如果传入了 源节点的锚点信息 则取源节点锚点的位置作为最近的判断标准
+    x = +sourceTargetX;
+    y = +sourceTargetY;
+  }
+
   let closest;
   let minDistance = Number.MAX_SAFE_INTEGER;
   for (let i = 0; i < anchors.length; i++) {
-    const len = distance(position.x, position.y, anchors[i].x, anchors[i].y);
+    const len = distance(x, y, anchors[i].x, anchors[i].y);
     if (len < minDistance) {
       minDistance = len;
       closest = {

--- a/packages/core/src/util/node.ts
+++ b/packages/core/src/util/node.ts
@@ -68,7 +68,11 @@ const getClosestAnchor = (position: Point, node: BaseNode): AnchorInfo => {
   const anchors = getAnchors(node);
   const { sourceTargetX, sourceTargetY } = position;
   let { x, y } = position;
-  if (!Number.isNaN(+sourceTargetX) && !Number.isNaN(+sourceTargetY)) {
+  // 由于 null 会被转换成 0  所以需要处理
+  if (
+    sourceTargetX !== null && !Number.isNaN(+sourceTargetX)
+    && sourceTargetY !== null && !Number.isNaN(+sourceTargetY)
+  ) {
     // 如果传入了 源节点的锚点信息 则取源节点锚点的位置作为最近的判断标准
     x = +sourceTargetX;
     y = +sourceTargetY;

--- a/packages/core/src/view/Anchor.tsx
+++ b/packages/core/src/view/Anchor.tsx
@@ -154,8 +154,14 @@ class Anchor extends Component<IProps, IState> {
     // nodeModel.setSelected(false);
     /* 创建连线 */
     const { nodes, edgeType } = graphModel;
-    const { endX, endY, draging } = this.state;
-    const info = targetNodeInfo({ x: endX, y: endY }, nodes);
+    const { endX, endY, draging, startX, startY } = this.state;
+    const info = targetNodeInfo({
+      x: endX,
+      y: endY,
+      sourceTargetX: startX,
+      sourceTargetY: startY,
+    }, nodes);
+    // feat 小优化 获取离目标节点最近的
     // 为了保证鼠标离开的时候，将上一个节点状态重置为正常状态。
     if (this.preTargetNode && this.preTargetNode.state !== ElementState.DEFAULT) {
       this.preTargetNode.setElementState(ElementState.DEFAULT);


### PR DESCRIPTION
current situation:
![动画-不期望](https://user-images.githubusercontent.com/33365722/146177647-23033f2a-aa27-4aef-b4bd-7a06c05f0e3f.gif)
The best anchor of target node is the closest anchor from the position of mouse.  But i expect it should be closer to the source node;
Like this:
![动画-期望](https://user-images.githubusercontent.com/33365722/146178260-198f4dd5-0d81-4e7e-9608-67e84b4641ea.gif)

