### PR TITLE
使用extension的国际化(i18n)支持

### DIFF
--- a/packages/core/src/LogicFlow.tsx
+++ b/packages/core/src/LogicFlow.tsx
@@ -1024,6 +1024,14 @@ export default class LogicFlow {
   setView(type: string, component) {
     this.viewMap.set(type, component);
   }
+  /**
+     * 内部保留方法
+     * 用于支持国际化
+     */
+  static t(text: string): string {
+    return text;
+  }
+
   renderRawData(graphRawData) {
     this.graphModel.graphDataToModel(formatData(graphRawData));
     if (!this.options.isSilentMode && this.options.history !== false) {

--- a/packages/extension/examples/locale/index.html
+++ b/packages/extension/examples/locale/index.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="format-detection" content="telephone=no, email=no">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title>LOGIC FLOW</title>
+  <link rel="stylesheet" href="/core/dist/style/index.css">
+  <link rel="stylesheet" href="/extension/src/style/index.css">
+  <style>
+    html,body {
+      padding: 0;
+      margin: 0;
+    }
+    body {
+      background-color: #FFF;
+    }
+    .rules-graph {
+      margin-top: 30px;
+      margin-left: 30px;
+      position: relative;
+    }
+    .pattern {
+      position: absolute;
+      left: 0;
+      top: 0;
+      width: 50px;
+      display: flex;
+      flex-direction: column;
+      z-index: 111;
+      align-items: center;
+      background: rgba(255,255,255,0.8);
+      box-shadow: 0 1px 4px rgba(0,0,0,.3);
+      padding: 10px 0;
+    }
+    #app {
+      width: 500px;
+      height: 500px;
+      border: 1px solid #efefef;
+    }
+  </style>
+</head>
+<body>
+  <div class="rules-graph">
+    <select class="locale-switcher">
+      <option value="en">English</option>
+      <option value="zh-hans">Chinese (中文)</option>
+    </select>
+    <div id="app"></div>
+  </div>
+  <script src="/core/dist/logic-flow.js"></script>
+  <script src="./index.js"></script>
+  <script src="/DndPanel.js"></script>
+  <script src="/EnLocale.js"></script>
+  <script src="/Menu.js"></script>
+  <script src="/Control.js"></script>
+  <script>
+    LogicFlow.use(EnLocale);
+    LogicFlow.use(Menu);
+    LogicFlow.use(Control);
+    LogicFlow.use(DndPanel);
+  </script>
+</body>
+</html>

--- a/packages/extension/examples/locale/index.js
+++ b/packages/extension/examples/locale/index.js
@@ -1,0 +1,22 @@
+window.onload = function () {
+  console.log(LogicFlow)
+  console.log(window)
+  const lf = new LogicFlow({
+    container: document.querySelector('#app'),
+    // fixme: grid成为了必传的了
+    grid: {
+      type: 'dot',
+      size: 20,
+    }
+  });
+
+  lf.extension.dndPanel.setPatternItems([
+    {
+      type: "circle",
+      text: "开始",
+      label: "开始节点",
+      icon: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAYAAAH6ji2bAAAABGdBTUEAALGPC/xhBQAAAnBJREFUOBGdVL1rU1EcPfdGBddmaZLiEhdx1MHZQXApraCzQ7GKLgoRBxMfcRELuihWKcXFRcEWF8HBf0DdDCKYRZpnl7p0svLe9Zzbd29eQhTbC8nv+9zf130AT63jvooOGS8Vf9Nt5zxba7sXQwODfkWpkbjTQfCGUd9gIp3uuPP8bZ946g56dYQvnBg+b1HB8VIQmMFrazKcKSvFW2dQTxJnJdQ77urmXWOMBCmXM2Rke4S7UAW+/8ywwFoewmBps2tu7mbTdp8VMOkIRAkKfrVawalJTtIliclFbaOBqa0M2xImHeVIfd/nKAfVq/LGnPss5Kh00VEdSzfwnBXPUpmykNss4lUI9C1ga+8PNrBD5YeqRY2Zz8PhjooIbfJXjowvQJBqkmEkVnktWhwu2SM7SMx7Cj0N9IC0oQXRo8xwAGzQms+xrB/nNSUWVveI48ayrFGyC2+E2C+aWrZHXvOuz+CiV6iycWe1Rd1Q6+QUG07nb5SbPrL4426d+9E1axKjY3AoRrlEeSQo2Eu0T6BWAAr6COhTcWjRaYfKG5csnvytvUr/WY4rrPMB53Uo7jZRjXaG6/CFfNMaXEu75nG47X+oepU7PKJvvzGDY1YLSKHJrK7vFUwXKkaxwhCW3u+sDFMVrIju54RYYbFKpALZAo7sB6wcKyyrd+aBMryMT2gPyD6GsQoRFkGHr14TthZni9ck0z+Pnmee460mHXbRAypKNy3nuMdrWgVKj8YVV8E7PSzp1BZ9SJnJAsXdryw/h5ctboUVi4AFiCd+lQaYMw5z3LGTBKjLQOeUF35k89f58Vv/tGh+l+PE/wG0rgfIUbZK5AAAAABJRU5ErkJggg==",
+    },
+  ]);
+  lf.render({})
+}

--- a/packages/extension/scripts/webpack.config.base.js
+++ b/packages/extension/scripts/webpack.config.base.js
@@ -20,6 +20,7 @@ const packagesEntry = {
   AutoLayout: path.resolve(__dirname, '../src/tools/auto-layout/index.ts'),
   lfXml2Json: path.resolve(__dirname, '../src/bpmn-adapter/xml2json.ts'),
   lfJson2Xml: path.resolve(__dirname, '../src/bpmn-adapter/json2xml.ts'),
+  EnLocale: path.resolve(__dirname, '../src/locale/en-locale/index.ts'),
   // GroupShrink: path.resolve(__dirname, '../src/group-shrink/index.ts'),
 };
 

--- a/packages/extension/src/components/control/index.ts
+++ b/packages/extension/src/components/control/index.ts
@@ -12,58 +12,61 @@ type ControlItem = {
 
 class Control {
   private lf: LogicFlow;
+  private LogicFlow: any;
   static pluginName = 'control';
-  private controlItems: ControlItem[] = [
-    {
-      key: 'zoom-out',
-      iconClass: 'lf-control-zoomOut',
-      title: '缩小流程图',
-      text: '缩小',
-      onClick: () => {
-        this.lf.zoom(false);
-      },
-    },
-    {
-      key: 'zoom-in',
-      iconClass: 'lf-control-zoomIn',
-      title: '放大流程图',
-      text: '放大',
-      onClick: () => {
-        this.lf.zoom(true);
-      },
-    },
-    {
-      key: 'reset',
-      iconClass: 'lf-control-fit',
-      title: '恢复流程原有尺寸',
-      text: '适应',
-      onClick: () => {
-        this.lf.resetZoom();
-      },
-    },
-    {
-      key: 'undo',
-      iconClass: 'lf-control-undo',
-      title: '回到上一步',
-      text: '上一步',
-      onClick: () => {
-        this.lf.undo();
-      },
-    },
-    {
-      key: 'redo',
-      iconClass: 'lf-control-redo',
-      title: '移到下一步',
-      text: '下一步',
-      onClick: () => {
-        this.lf.redo();
-      },
-    },
-  ];
+  private controlItems: ControlItem[];
   private domContainer: HTMLElement;
   private toolEl: HTMLElement;
-  constructor({ lf }) {
-    this.lf = lf;
+  constructor(args) {
+    this.lf = args.lf;
+    this.LogicFlow = args.LogicFlow;
+    this.controlItems = [
+      {
+        key: 'zoom-out',
+        iconClass: 'lf-control-zoomOut',
+        title: this.LogicFlow.t('缩小流程图'),
+        text: this.LogicFlow.t('缩小'),
+        onClick: () => {
+          this.lf.zoom(false);
+        },
+      },
+      {
+        key: 'zoom-in',
+        iconClass: 'lf-control-zoomIn',
+        title: this.LogicFlow.t('放大流程图'),
+        text: this.LogicFlow.t('放大'),
+        onClick: () => {
+          this.lf.zoom(true);
+        },
+      },
+      {
+        key: 'reset',
+        iconClass: 'lf-control-fit',
+        title: this.LogicFlow.t('恢复流程原有尺寸'),
+        text: this.LogicFlow.t('适应'),
+        onClick: () => {
+          this.lf.resetZoom();
+        },
+      },
+      {
+        key: 'undo',
+        iconClass: 'lf-control-undo',
+        title: this.LogicFlow.t('回到上一步'),
+        text: this.LogicFlow.t('上一步'),
+        onClick: () => {
+          this.lf.undo();
+        },
+      },
+      {
+        key: 'redo',
+        iconClass: 'lf-control-redo',
+        title: this.LogicFlow.t('移到下一步'),
+        text: this.LogicFlow.t('下一步'),
+        onClick: () => {
+          this.lf.redo();
+        },
+      },
+    ];
   }
   render(lf, domContainer) {
     this.destroy();

--- a/packages/extension/src/components/menu/index.ts
+++ b/packages/extension/src/components/menu/index.ts
@@ -22,14 +22,16 @@ const DefalutSelectionMenuKey = 'lf:defaultSelectionMenu';
 
 class Menu {
   lf: LogicFlow;
+  LogicFlow: any;
   private __container: HTMLElement;
   private __menuDOM: HTMLElement;
   private menuTypeMap: Map<string, MenuItem[]>;
   private __currentData: any;
   static pluginName = 'menu';
-  constructor({ lf }) {
+  constructor(args) {
     this.__menuDOM = document.createElement('ul');
-    this.lf = lf;
+    this.lf = args.lf;
+    this.LogicFlow = args.LogicFlow;
     this.menuTypeMap = new Map();
     this.init();
     this.lf.setMenuConfig = (config) => {
@@ -48,19 +50,19 @@ class Menu {
   private init() {
     const defalutNodeMenu = [
       {
-        text: '删除',
+        text: this.LogicFlow.t('删除'),
         callback: (node) => {
           this.lf.deleteNode(node.id);
         },
       },
       {
-        text: '编辑文本',
+        text: this.LogicFlow.t('编辑文本'),
         callback: (node) => {
           this.lf.graphModel.editText(node.id);
         },
       },
       {
-        text: '复制',
+        text: this.LogicFlow.t('复制'),
         callback: (node) => {
           this.lf.cloneNode(node.id);
         },
@@ -70,13 +72,13 @@ class Menu {
 
     const defaultEdgeMenu = [
       {
-        text: '删除',
+        text: this.LogicFlow.t('删除'),
         callback: (edge) => {
           this.lf.deleteEdge(edge.id);
         },
       },
       {
-        text: '编辑文本',
+        text: this.LogicFlow.t('编辑文本'),
         callback: (edge) => {
           this.lf.graphModel.editText(edge.id);
         },
@@ -88,7 +90,7 @@ class Menu {
 
     const DefalutSelectionMenu = [
       {
-        text: '删除',
+        text: this.LogicFlow.t('删除'),
         callback: (elements) => {
           this.lf.clearSelectElements();
           elements.edges.forEach(edge => this.lf.deleteEdge(edge.id));

--- a/packages/extension/src/index.ts
+++ b/packages/extension/src/index.ts
@@ -17,3 +17,4 @@ export * from './tools/flow-path';
 export * from './tools/auto-layout';
 export * from './bpmn-adapter/xml2json';
 export * from './bpmn-adapter/json2xml';
+export * from './locale/en-locale';

--- a/packages/extension/src/locale/en-locale/en.ts
+++ b/packages/extension/src/locale/en-locale/en.ts
@@ -1,0 +1,22 @@
+const en = {
+  文本: 'text',
+  开始: 'start',
+  缩小流程图: 'zoom in',
+  缩小: 'zoom in',
+  放大流程图: 'zoom out',
+  放大: 'zoom out',
+  恢复流程原有尺寸: 'adapt to original size',
+  适应: 'adapt',
+  回到上一步: 'undo',
+  上一步: 'undo',
+  移到下一步: 'redo',
+  下一步: 'redo',
+
+  删除: 'delete',
+  编辑文本: 'edit text',
+  复制: 'copy',
+};
+
+export default en;
+
+export { en };

--- a/packages/extension/src/locale/en-locale/index.ts
+++ b/packages/extension/src/locale/en-locale/index.ts
@@ -1,0 +1,13 @@
+import { Locale } from '../locale';
+import en from './en';
+
+class EnLocale extends Locale {
+  static pluginName = 'enLocale';
+  constructor({ LogicFlow }) {
+    super(LogicFlow, en);
+  }
+}
+
+export default EnLocale;
+
+export { EnLocale };

--- a/packages/extension/src/locale/locale.ts
+++ b/packages/extension/src/locale/locale.ts
@@ -1,0 +1,17 @@
+export class Locale {
+  constructor(LogicFlow?: any, map?: Object) {
+    if (LogicFlow && map) {
+      this.replaceTranslator(LogicFlow, map);
+    }
+  }
+
+  replaceTranslator(LogicFlow: any, map: Object) {
+    LogicFlow.t = (text: string) => (map[text] ? map[text] : text);
+  }
+
+  setDefault(LogicFlow: any) {
+    LogicFlow.t = Locale.defaultTranslator;
+  }
+
+  static defaultTranslator = (text: string) => text;
+}


### PR DESCRIPTION
issue #569 
实现：
- 在`LogicFlow`类中添加了一个static翻译函数`t`
- 名为`EnLocale`的`extension`创建时更改翻译函数到相应语言
- 使用中文原文索引翻译，中文是默认语言

问题：
- 不支持切换语言/设置地区时，自动刷新所有文本到目标语言
- `t`函数全局的方式实现得比较麻烦