### PR TITLE
fix(extension-selection): 修复开启selection后,右键仍会出现上下文菜单的问题

### DIFF
--- a/packages/extension/src/components/selection-select/index.ts
+++ b/packages/extension/src/components/selection-select/index.ts
@@ -44,6 +44,9 @@ class SelectionSelect {
       this.endPoint = { x, y };
       const wrapper = document.createElement('div');
       wrapper.className = 'lf-selection-select';
+      wrapper.oncontextmenu = function prevent(ev: PointerEvent) {
+        ev.preventDefault();
+      };
       wrapper.style.top = `${this.startPoint.y}px`;
       wrapper.style.left = `${this.startPoint.x}px`;
       domContainer.appendChild(wrapper);
@@ -112,6 +115,7 @@ class SelectionSelect {
   __drawOff = () => {
     document.removeEventListener('mousemove', this.__draw);
     document.removeEventListener('mouseup', this.__drawOff);
+    this.wrapper.oncontextmenu = null;
     this.__domContainer.removeChild(this.wrapper);
     const { x, y } = this.startPoint;
     const { x: x1, y: y1 } = this.endPoint;


### PR DESCRIPTION
当右键mousedown实践触发时,会创建选框元素,并在该元素上触发 contextmenu 事件导致出现菜单