### PR TITLE
fix:编辑状态下的字体样式与非编辑态样式保持一致

### DIFF
--- a/packages/core/src/tool/TextEditTool.tsx
+++ b/packages/core/src/tool/TextEditTool.tsx
@@ -123,11 +123,13 @@ export default class TextEdit extends Component<IProps, IState> {
       }
       const { x, y } = textEditElement.text;
       const [left, top] = transformModel.CanvasPointToHtmlPoint([x, y]);
+      const textStyle = textEditElement.getTextStyle();
       return {
         style: {
           left,
           top,
           ...autoStyle,
+          ...textStyle,
         },
       };
     }


### PR DESCRIPTION
编辑状态下的字体样式与非编辑态样式保持一致
<img width="172" alt="image" src="https://user-images.githubusercontent.com/34210271/173171507-0426fd29-29a6-4ecf-bfa6-73be234e34a5.png">
<img width="195" alt="image" src="https://user-images.githubusercontent.com/34210271/173171511-774e7405-8fe9-4d7e-a847-3c728afaf887.png">
