### PR TITLE
chore: use `fs` replace `cp` for support the build script in windows

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,12 +17,13 @@
     "dev": "cross-env NODE_ENV=development webpack-dev-server --client-log-level warning --config scripts/webpack.config.dev.js",
     "clean": "rimraf dist lib esm cjs",
     "build": "npm run build:umd",
-    "build:umd": "cross-env NODE_ENV=production webpack --config scripts/webpack.config.build.js && cp -r src/style/ dist/style && cp scripts/entry.js dist",
+    "build:umd": "cross-env NODE_ENV=production webpack --config scripts/webpack.config.build.js && npm run copy",
     "build-analyse": "cross-env analyse=true npm run build",
     "types": "tsc -d --declarationDir ./types --outDir temp && rimraf temp",
     "lint": "eslint . --ext .ts,.tsx",
     "publish-lib": "npm run types & npm run clean && npm run build && npm publish",
-    "publish-next": "npm run types & npm run clean && npm run build && npm publish --tag next"
+    "publish-next": "npm run types & npm run clean && npm run build && npm publish --tag next",
+    "copy":"node ./scripts/copy.js"
   },
   "files": [
     "dist",

--- a/packages/core/scripts/copy.js
+++ b/packages/core/scripts/copy.js
@@ -1,0 +1,41 @@
+const { copyFile, statSync, mkdirSync, existsSync, readdir } = require('fs');
+const path = require('path');
+const sourcePath = path.resolve(__dirname, './entry.js');
+const targetPath = path.resolve(__dirname, '../dist/entry.js');
+const sourceDir = path.resolve(__dirname, '../src/style');
+const targetDir = path.resolve(__dirname, '../dist/style');
+
+const copyFolder = async (src, dst) => {
+  readdir(src, (err, files) => {
+    if (!err) {
+      if (!existsSync(dst)) mkdirSync(dst);
+      files.forEach((file) => {
+        const srcPath = path.join(src, file);
+        const dstPath = path.join(dst, file);
+        const status = statSync(srcPath);
+        if (status.isFile()) {
+          copyFile(srcPath, dstPath, (err) => {
+            if (err) {
+              console.log(err);
+              process.exit(1);
+            }
+          });
+        } else if (status.isDirectory()) {
+          copyFolder(srcPath, dstPath);
+        }
+      });
+    } else {
+      console.log(err);
+      process.exit(1);
+    }
+  });
+};
+
+copyFile(sourcePath, targetPath, (err) => {
+  if (err) {
+    console.log(err);
+    process.exit(1);
+  }
+});
+
+copyFolder(sourceDir, targetDir);

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -15,12 +15,12 @@
   "scripts": {
     "dev": "cross-env NODE_ENV=development webpack-dev-server --client-log-level warning --config scripts/webpack.config.dev.js",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "style": "echo ./cjs ./es ./lib | xargs -n 1 cp -v -r ./src/style",
+    "copy": "node ./scripts/copy.js",
     "types": "tsc -d --declarationDir ./types --outDir temp && rimraf -R temp",
     "build:esm": "tsc --module esnext --target es5 --outDir ./es -d",
     "build:cjs": "tsc --module commonjs --target es5 --outDir ./cjs",
     "build:umd": "cross-env NODE_ENV=production webpack --config scripts/webpack.config.build.js",
-    "build": "rimraf ./es ./cjs ./lib && npm run build:esm & npm run build:cjs & npm run build:umd && npm run style",
+    "build": "rimraf ./es ./cjs ./lib && npm run build:esm & npm run build:cjs & npm run build:umd && npm run copy",
     "publish-lib": "npm run build && npm publish"
   },
   "author": "",

--- a/packages/extension/scripts/copy.js
+++ b/packages/extension/scripts/copy.js
@@ -1,0 +1,35 @@
+const { copyFile, statSync, mkdirSync, existsSync, readdir } = require('fs');
+const path = require('path');
+
+const copyFolder = async (src, dst) => {
+  readdir(src, (err, files) => {
+    if (!err) {
+      if (!existsSync(dst)) mkdirSync(dst);
+      files.forEach((file) => {
+        const srcPath = path.join(src, file);
+        const dstPath = path.join(dst, file);
+        const status = statSync(srcPath);
+        if (status.isFile()) {
+          copyFile(srcPath, dstPath, (err) => {
+            if (err) {
+              console.log(err);
+              process.exit(1);
+            }
+          });
+        } else if (status.isDirectory()) {
+          copyFolder(srcPath, dstPath);
+        }
+      });
+    } else {
+      console.log(err);
+      process.exit(1);
+    }
+  });
+};
+
+const targetDirs = ['../cjs/style', '../es/style', '../lib/style'];
+const sourceDir = path.resolve(__dirname, '../src/style');
+
+targetDirs.forEach((dir) => {
+  copyFolder(sourceDir, path.resolve(__dirname, dir));
+});


### PR DESCRIPTION
affects: @logicflow/core, @logicflow/extension

ISSUES CLOSED: #657