### PR TITLE
feat: 增加 edgeGenerator 选项, 可自定义连边规则

### DIFF
--- a/docs/api/logicFlowApi.md
+++ b/docs/api/logicFlowApi.md
@@ -45,6 +45,7 @@ const lf = new LogicFlow(options: Options)
 |edgeTextDraggable|boolean| - |false|允许边文本可以拖拽|
 |multipleSelectKey|string| - |-|多选按键, 可选meta(cmd)、shift、alt。 支持组合键点击元素实现多选|
 |idGenerator|function| -|-|自定义创建节点、连线时生成id规则。|
+|edgeGenerator|function| -|-|连接节点及移动边时边的生成规则|
 |plugins|Array| -|-|当前LogicFlow实例加载的插件，不传则采用全局插件。|
 |autoExpand|boolean| -|-|节点拖动靠近画布边缘时是否自动扩充画布, 默认true。|
 |overlapMode|number|-|-|元素重合的堆叠模式，默认为连线在下、节点在上，选中元素在最上面。可以设置为1，表示自增模式（作图工具场景常用）。|

--- a/docs/guide/basic/edge.md
+++ b/docs/guide/basic/edge.md
@@ -266,7 +266,24 @@ class CustomEdgeModel extends PolylineEdgeModel {
     return style;
   }
 }
-``` 
+```
+
+## 自定义不同节点连接的边的规则
+初始化流程图时, 可以通过 `edgeType` 设置默认的边. 当不同节点需要使用的边时, 则可以通过 `edgeGenerator` 来定义使用边的规则.
+
+```js
+const lf = new LogicFlow({
+  ...,
+  // 默认边
+  edgeType: 'bezier',
+  // 移动已有边时会有 currentEdge 信息, 否则为空
+  edgeGenerator: (sourceNode, targetNode, currentEdge) => {
+    // 起始节点类型 rect 时使用 自定义的边 custom-edge
+    if (sourceNode.type === 'rect') return 'custom-edge'
+  }
+})
+
+```
 
 ### 示例
 

--- a/packages/core/src/model/GraphModel.ts
+++ b/packages/core/src/model/GraphModel.ts
@@ -22,7 +22,7 @@ import { updateTheme } from '../util/theme';
 import EventEmitter from '../event/eventEmitter';
 import { snapToGrid, getGridOffset } from '../util/geometry';
 import { isPointInArea } from '../util/graph';
-import { getClosestPointOfPolyline } from '../util/edge';
+import { getClosestPointOfPolyline, createEdgeGenerator } from '../util/edge';
 import { formatData } from '../util/compatible';
 import { getNodeAnchorPosition, getNodeBBox } from '../util/node';
 import { createUuid } from '../util';
@@ -81,6 +81,10 @@ class GraphModel {
    * @see todo docs link
    */
   idGenerator: (type?: string) => string;
+  /**
+   * 节点间连线、连线变更时的边的生成规则
+   */
+  edgeGenerator: Definition['edgeGenerator'];
   /**
    * 节点移动规则判断
    * 在节点移动的时候，会出发此数组中的所有规则判断
@@ -141,6 +145,7 @@ class GraphModel {
       background = {},
       grid,
       idGenerator,
+      edgeGenerator,
       animation,
     } = options;
     this.background = background;
@@ -159,6 +164,7 @@ class GraphModel {
     this.partial = options.partial;
     this.overlapMode = options.overlapMode || 0;
     this.idGenerator = idGenerator;
+    this.edgeGenerator = createEdgeGenerator(this, edgeGenerator);
     this.width = options.width || this.rootEl.getBoundingClientRect().width;
     this.height = options.height || this.rootEl.getBoundingClientRect().height;
   }

--- a/packages/core/src/options.ts
+++ b/packages/core/src/options.ts
@@ -106,6 +106,18 @@ export type Definition = {
    * AnimationConfig: 配置部分动画开启
    */
   animation?: boolean | Partial<AnimationConfig>;
+
+  /**
+   * 节点间连线、连线变更时的边的生成规则
+   * @param sourceNode 起始节点数据
+   * @param targetNode 终止节点数据
+   * @param currentEdge 当前边的数据, 仅移动已有边的时候有值
+   *
+   * @return undefined: 使用默认边
+   *        string: 自定义边类型
+   *        any: 自定义边及其他数据
+   */
+  edgeGenerator?: (sourceNode: any, targetNode: any, currentEdge?: any) => string | any | undefined;
   [key: string]: any;
 } & EditConfigInterface;
 

--- a/packages/core/src/util/edge.ts
+++ b/packages/core/src/util/edge.ts
@@ -885,3 +885,24 @@ export const twoPointDistance = (source: Position, target: Position) => {
   // };
   return Math.sqrt((source.x - target.x) ** 2 + (source.y - target.y) ** 2);
 };
+
+/**
+ * 包装边生成函数
+ * @param graphModel graph model
+ * @param generator 用户自定义的边生成函数
+ */
+export function createEdgeGenerator(graphModel: any, generator?: Function) {
+  if (typeof generator !== 'function') {
+    return (sourceNode: any, targetNode: any, currentEdge?: any) => Object.assign({
+      type: graphModel.edgeType }, currentEdge);
+  }
+  return (sourceNode: any, targetNode: any, currentEdge?: any) => {
+    const result = generator(sourceNode, targetNode, currentEdge);
+    // 无结果使用默认类型
+    if (!result) return { type: graphModel.edgeType };
+    if (typeof result === 'string') {
+      return Object.assign({}, currentEdge, { type: result });
+    }
+    return Object.assign({ type: result }, currentEdge);
+  };
+}

--- a/packages/core/src/view/Anchor.tsx
+++ b/packages/core/src/view/Anchor.tsx
@@ -216,8 +216,12 @@ class Anchor extends Component<IProps, IState> {
       } = this.targetRuleResults.get(targetInfoId) || {};
       if (isSourcePass && isTargetPass) {
         targetNode.setElementState(ElementState.DEFAULT);
+        const edgeData = graphModel.edgeGenerator(
+          nodeModel.getData(),
+          graphModel.getNodeModelById(info.node.id).getData(),
+        );
         const edgeModel = graphModel.addEdge({
-          type: edgeType,
+          ...edgeData,
           sourceNodeId: nodeModel.id,
           sourceAnchorId: id,
           startPoint: { x, y },

--- a/packages/core/src/view/edge/AdjustPoint.tsx
+++ b/packages/core/src/view/edge/AdjustPoint.tsx
@@ -142,8 +142,13 @@ export default class AdjustPoint extends Component<IProps, IState> {
       };
       // 根据调整点是边的起点或重点，计算创建边需要的参数
       if (type === AdjustType.SOURCE) {
+        const edgeInfo = graphModel.edgeGenerator(
+          graphModel.getNodeModelById(info.node.id).getData(),
+          graphModel.getNodeModelById(edgeModel.targetNodeId).getData(),
+          createEdgeInfo,
+        );
         createEdgeInfo = {
-          ...createEdgeInfo,
+          ...edgeInfo,
           sourceNodeId: info.node.id,
           sourceAnchorId: info.anchor.id,
           startPoint: { x: info.anchor.x, y: info.anchor.y },
@@ -151,8 +156,13 @@ export default class AdjustPoint extends Component<IProps, IState> {
           endPoint: { ...edgeModel.endPoint },
         };
       } else if (type === AdjustType.TARGET) {
+        const edgeInfo = graphModel.edgeGenerator(
+          graphModel.getNodeModelById(edgeModel.sourceNodeId).getData(),
+          graphModel.getNodeModelById(info.node.id).getData(),
+          createEdgeInfo,
+        );
         createEdgeInfo = {
-          ...createEdgeInfo,
+          ...edgeInfo,
           sourceNodeId: edgeModel.sourceNodeId,
           startPoint: { ...edgeModel.startPoint },
           targetNodeId: info.node.id,


### PR DESCRIPTION
## 需求
在项目中, 需要特定的节点连线时使用特定的边, 比如:
 - 注释节点 使用虚线连接其他节点
 - 分支节点连接到其他节点时使用自定义样式的边

此种情况, 使用 `edgeType` 无法满足需求

## 提案
给 LogicFlow 增加参数 `edgeGenerator`

```ts
export type Definition = {
  /**
   * 节点间连线、连线变更时的边的生成规则
   * @param sourceNode 起始节点数据
   * @param targetNode 终止节点数据
   * @param currentEdge 当前边的数据, 仅移动已有边的时候有值
   *
   * @return undefined: 使用默认边
   *        string: 自定义边类型
   *        any: 自定义边及其他数据
   */
  edgeGenerator?: (sourceNode: any, targetNode: any, currentEdge?: any) => string | any | undefined;
}
```

## 使用示例
```js
const lf = new LogicFlow({
  ...,
  // 默认边
  edgeType: 'bezier',
  // 移动已有边时会有 currentEdge 信息, 否则为空
  edgeGenerator: (sourceNode, targetNode, currentEdge) => {
    // 起始节点类型 rect 时使用 自定义的边 custom-edge
    if (sourceNode.type === 'rect') return 'custom-edge'
  }
})
```

文档和示例可能还需要再完善下 😄 


