### PR TITLE
fix: 修正 BaseEdgeModel 构造函数属性初始化顺序

### DIFF
--- a/packages/core/src/model/edge/BaseEdgeModel.ts
+++ b/packages/core/src/model/edge/BaseEdgeModel.ts
@@ -72,13 +72,6 @@ class BaseEdgeModel implements IBaseModel {
     this.graphModel = graphModel;
     this.initEdgeData(data);
     this.setAttributes();
-    // 设置边的 anchors，也就是边的两个端点
-    // 端点依赖于 edgeData 的 sourceNode 和 targetNode
-    this.setAnchors();
-    // 边的拐点依赖于两个端点
-    this.initPoints();
-    // 文本位置依赖于边上的所有拐点
-    this.formatText(data);
   }
   /**
    * @overridable 支持重写
@@ -106,6 +99,13 @@ class BaseEdgeModel implements IBaseModel {
     if (overlapMode === OverlapMode.INCREASE) {
       this.zIndex = data.zIndex || getZIndex();
     }
+    // 设置边的 anchors，也就是边的两个端点
+    // 端点依赖于 edgeData 的 sourceNode 和 targetNode
+    this.setAnchors();
+    // 边的拐点依赖于两个端点
+    this.initPoints();
+    // 文本位置依赖于边上的所有拐点
+    this.formatText(data);
   }
   /**
    * 设置model属性，每次properties发生变化会触发


### PR DESCRIPTION
调整 BaseEdgeModel 的构造函数的属性初始化顺序, 修正在构造边实例的时候无法通过 initEdgeData 和 setAttributes 去自定义 文本 的问题.

修正前, 实现自定义文本办法
```js
class BranchEdgeModel extends PolylineEdgeModel {
  initEdgeData(data: any): void {
    super.initEdgeData(data)
    // 保证 formatText 能在初始化时拿到自定义的 文本
    data.text = this.properties.title || ''
  }
  setAttributes() {
    this.updateText(this.properties.title)
  }
}
```

修正后:
```js
class BranchEdgeModel extends PolylineEdgeModel {
  setAttributes() {
    this.updateText(this.properties.title)
  }
}
```

