### PR TITLE
ResizeNode 等比缩放功能合并

### DIFF
--- a/packages/extension/examples/NodeResize/index.html
+++ b/packages/extension/examples/NodeResize/index.html
@@ -9,7 +9,7 @@
   <!-- <link rel="stylesheet" href="http://0.0.0.0:9099/src/style/index.css"> -->
   <link rel="stylesheet" href="/extension/src/style/index.css">
   <link rel="stylesheet" href="./style.css" >
-  
+
   <style>
     html,body {
       padding: 0;
@@ -54,11 +54,13 @@
   <button id="data">获取数据</button>
   <div id="app"></div>
   <!-- <script src="/core/dist/logic-flow.js"></script> -->
-  <script src="http://0.0.0.0:9093/logic-flow.js"></script>
+  <script src="/core/dist/logic-flow.js"></script>
   <script src="/NodeResize.js"></script>
+  <script src="/Menu.js"> </script>
   <script>
     // NodeResize.step = 2;
     LogicFlow.use(NodeResize);
+    LogicFlow.use(Menu);
   </script>
   <script type="module" src="./index.mjs"></script>
 </body>

--- a/packages/extension/examples/NodeResize/index.mjs
+++ b/packages/extension/examples/NodeResize/index.mjs
@@ -22,6 +22,41 @@ window.onload = function () {
   lf.register(ResizableHtml);
   lf.register(ResizableHexagon);
 
+  lf.extension.menu.setMenuConfig({
+    nodeMenu: [
+      {
+        text: '开启等比例缩放',
+        callback(data) {
+          const model = lf.getNodeModelById(data.id);
+          if (model) {
+            try {
+              model.enableProportionResize();
+              console.log('开启等比例缩放');
+            } catch (error) {
+              console.log('enableProportionResize() 方法未定义');
+            }
+          }
+        }
+      },
+      {
+        text: '关闭等比例缩放',
+        callback(data) {
+          const model = lf.getNodeModelById(data.id);
+          if (model) {
+            try {
+              model.enableProportionResize(false);
+              console.log('关闭等比例缩放');
+            } catch (error) {
+              console.log('enableProportionResize() 方法未定义');
+            }
+          }
+        }
+      },
+    ],
+    edgeMenu: [],
+    graphMenu: []
+  });
+
   lf.render({
     nodes: [
       {

--- a/packages/extension/src/NodeResize/Node/DiamondResize.tsx
+++ b/packages/extension/src/NodeResize/Node/DiamondResize.tsx
@@ -14,6 +14,11 @@ interface IProps {
   edgeStyle?: CSSStyleDeclaration,
 }
 class DiamondResizeModel extends DiamondNodeModel {
+  private PCTResizeInfo: {
+    ResizePCT: { widthPCT: number, hightPCT: number },
+    ResizeBasis: { basisWidth: number, basisHeight: number },
+    ScaleLimit: { maxScaleLimit: number, minScaleLimit: number}
+  };
   constructor(data, graphModel) {
     super(data, graphModel);
     const { nodeSize } = this.properties;
@@ -58,6 +63,22 @@ class DiamondResizeModel extends DiamondNodeModel {
       fill: '#FFFFFF',
       stroke: '#000000',
     };
+  }
+  // 该方法需要在重设宽高和最大、最小限制后被调用，不建议在 initNodeData() 方法中使用
+  enableProportionResize(turnOn = true) {
+    if (turnOn) {
+      const ResizePCT = { widthPCT: 100, hightPCT: 100 };
+      const ResizeBasis = { basisWidth: this.rx, basisHeight: this.ry };
+      const ScaleLimit = {
+        maxScaleLimit: Math.min((this.maxWidth / (this.rx * 2)) * 100,
+          (this.maxHeight / (this.ry * 2)) * 100),
+        minScaleLimit: Math.max((this.minWidth / (this.rx * 2)) * 100,
+          (this.minHeight / (this.ry * 2)) * 100),
+      };
+      this.PCTResizeInfo = { ResizePCT, ResizeBasis, ScaleLimit };
+    } else {
+      delete this.PCTResizeInfo;
+    }
   }
 }
 class DiamondResizeView extends DiamondNode {

--- a/packages/extension/src/NodeResize/Node/EllipseResize.tsx
+++ b/packages/extension/src/NodeResize/Node/EllipseResize.tsx
@@ -13,6 +13,11 @@ interface IProps {
   edgeStyle?: CSSStyleDeclaration,
 }
 class EllipseResizeModel extends EllipseNodeModel {
+  private PCTResizeInfo: {
+    ResizePCT: { widthPCT: number, hightPCT: number },
+    ResizeBasis: { basisWidth: number, basisHeight: number },
+    ScaleLimit: { maxScaleLimit: number, minScaleLimit: number}
+  };
   constructor(data, graphModel) {
     super(data, graphModel);
     const { nodeSize } = this.properties;
@@ -56,6 +61,22 @@ class EllipseResizeModel extends EllipseNodeModel {
       fill: '#FFFFFF',
       stroke: '#000000',
     };
+  }
+  // 该方法需要在重设宽高和最大、最小限制后被调用，不建议在 initNodeData() 方法中使用
+  enableProportionResize(turnOn = true) {
+    if (turnOn) {
+      const ResizePCT = { widthPCT: 100, hightPCT: 100 };
+      const ResizeBasis = { basisWidth: this.rx, basisHeight: this.ry };
+      const ScaleLimit = {
+        maxScaleLimit: Math.min((this.maxWidth / (this.rx * 2)) * 100,
+          (this.maxHeight / (this.ry * 2)) * 100),
+        minScaleLimit: Math.max((this.minWidth / (this.rx * 2)) * 100,
+          (this.minHeight / (this.ry * 2)) * 100),
+      };
+      this.PCTResizeInfo = { ResizePCT, ResizeBasis, ScaleLimit };
+    } else {
+      delete this.PCTResizeInfo;
+    }
   }
 }
 class EllipseResizeView extends EllipseNode {

--- a/packages/extension/src/NodeResize/Node/HtmlResize.tsx
+++ b/packages/extension/src/NodeResize/Node/HtmlResize.tsx
@@ -13,6 +13,11 @@ interface IProps {
   edgeStyle?: CSSStyleDeclaration,
 }
 class HtmlResizeModel extends HtmlNodeModel {
+  private PCTResizeInfo: {
+    ResizePCT: { widthPCT: number, hightPCT: number },
+    ResizeBasis: { basisWidth: number, basisHeight: number },
+    ScaleLimit: { maxScaleLimit: number, minScaleLimit: number}
+  };
   constructor(data, graphModel) {
     super(data, graphModel);
     const { nodeSize } = this.properties;
@@ -56,6 +61,22 @@ class HtmlResizeModel extends HtmlNodeModel {
       fill: '#FFFFFF',
       stroke: '#000000',
     };
+  }
+  // 该方法需要在重设宽高和最大、最小限制后被调用，不建议在 initNodeData() 方法中使用
+  enableProportionResize(turnOn = true) {
+    if (turnOn) {
+      const ResizePCT = { widthPCT: 100, hightPCT: 100 };
+      const ResizeBasis = { basisWidth: this.width, basisHeight: this.height };
+      const ScaleLimit = {
+        maxScaleLimit: Math.min((this.maxWidth / this.width) * 100,
+          (this.maxHeight / this.height) * 100),
+        minScaleLimit: Math.max((this.minWidth / this.width) * 100,
+          (this.minHeight / this.height) * 100),
+      };
+      this.PCTResizeInfo = { ResizePCT, ResizeBasis, ScaleLimit };
+    } else {
+      delete this.PCTResizeInfo;
+    }
   }
 }
 class HtmlResizeView extends HtmlNode {

--- a/packages/extension/src/NodeResize/Node/RectResize.tsx
+++ b/packages/extension/src/NodeResize/Node/RectResize.tsx
@@ -13,6 +13,11 @@ interface IProps {
   edgeStyle?: CSSStyleDeclaration,
 }
 class RectResizeModel extends RectNodeModel {
+  private PCTResizeInfo: {
+    ResizePCT: { widthPCT: number, hightPCT: number },
+    ResizeBasis: { basisWidth: number, basisHeight: number },
+    ScaleLimit: { maxScaleLimit: number, minScaleLimit: number}
+  };
   constructor(data, graphModel) {
     super(data, graphModel);
     const { nodeSize } = this.properties;
@@ -60,6 +65,22 @@ class RectResizeModel extends RectNodeModel {
   }
   resize(deltaX, deltaY) {
     console.log(deltaX, deltaY);
+  }
+  // 该方法需要在重设宽高和最大、最小限制后被调用，不建议在 initNodeData() 方法中使用
+  enableProportionResize(turnOn = true) {
+    if (turnOn) {
+      const ResizePCT = { widthPCT: 100, hightPCT: 100 };
+      const ResizeBasis = { basisWidth: this.width, basisHeight: this.height };
+      const ScaleLimit = {
+        maxScaleLimit: Math.min((this.maxWidth / this.width) * 100,
+          (this.maxHeight / this.height) * 100),
+        minScaleLimit: Math.max((this.minWidth / this.width) * 100,
+          (this.minHeight / this.height) * 100),
+      };
+      this.PCTResizeInfo = { ResizePCT, ResizeBasis, ScaleLimit };
+    } else {
+      delete this.PCTResizeInfo;
+    }
   }
 }
 class RectResizeView extends RectNode {


### PR DESCRIPTION
提供 enableProportionResize() 方法开启/关闭等比缩放功能；
支持 RectResize、HtmlResize、EllipseResize、DiamondResize 等比拖拽缩放；
不影响原有基础功能；
修复椭圆和菱形（左上、左下、右上）拖拽时的BUG ；
已测试四个角的缩放效果，以及撤销/删除/回退等情况的影响；