### PR TITLE
feat: add event to dnd-penal

### DIFF
--- a/examples/src/pages/extension/components/dnd-panel/index.tsx
+++ b/examples/src/pages/extension/components/dnd-panel/index.tsx
@@ -60,7 +60,12 @@ export default function DndPanelExample() {
         icon: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAYAAAH6ji2bAAAABGdBTUEAALGPC/xhBQAAA1BJREFUOBFtVE1IVUEYPXOf+tq40Y3vPcmFIdSjIorWoRG0ERWUgnb5FwVhYQSl72oUoZAboxKNFtWiwKRN0M+jpfSzqJAQclHo001tKkjl3emc8V69igP3znzfnO/M9zcDcKT67azmjYWTwl9Vn7Vumeqzj1DVb6cleQY4oAVnIOPb+mKAGxQmKI5CWNJ2aLPatxWa3aB9K7/fB+/Z0jUF6TmMlFLQqrkECWQzOZxYGjTlOl8eeKaIY5yHnFn486xBustDjWT6dG7pmjHOJd+33t0iitTPkK6tEvjxq4h2MozQ6WFSX/LkDUGfFwfhEZj1Auz/U4pyAi5Sznd7uKzznXeVHlI/Aywmk6j7fsUsEuCGADrWARXXwjxWQsUbIupDHJI7kF5dRktg0eN81IbiZXiTESic50iwS+t1oJgL83jAiBupLDCQqwziaWSoAFSeIR3P5Xv5az00wyIn35QRYTwdSYbz8pH8fxUUAtxnFvYmEmgI0wYXUXcCCSpeEVpXlsRhBnCEATxWylL9+EKCAYhe1NGstUa6356kS9NVvt3DU2fd+Wtbm/+lSbylJqsqkSm9CRhvoJVlvKPvF1RKY/FcPn5j4UfIMLn8D4UYb54BNsilTDXKnF4CfTobA0FpoW/LSp306wkXM+XaOJhZaFkcNM82ASNAWMrhrUbRfmyeI1FvRBTpN06WKxa9BK0o2E4Pd3zfBBEwPsv9sQBnmLVbLEIZ/Xe9LYwJu/Er17W6HYVBc7vmuk0xUQ+pqxdom5Fnp55SiytXLPYoMXNM4u4SNSCFWnrVIzKG3EGyMXo6n/BQOe+bX3FClY4PwydVhthOZ9NnS+ntiLh0fxtlUJHAuGaFoVmttpVMeum0p3WEXbcll94l1wM/gZ0Ccczop77VvN2I7TlsZCsuXf1WHvWEhjO8DPtyOVg2/mvK9QqboEth+7pD6NUQC1HN/TwvydGBARi9MZSzLE4b8Ru3XhX2PBxf8E1er2A6516o0w4sIA+lwURhAON82Kwe2iDAC1Watq4XHaGQ7skLcFOtI5lDxuM2gZe6WFIotPAhbaeYlU4to5cuarF1QrcZ/lwrLaCJl66JBocYZnrNlvm2+MBCTmUymPrYZVbjdlr/BxlMjmNmNI3SAAAAAElFTkSuQmCC',
       }
     ]);
+    // 订阅dnd panel事件
+    // lf.graphModel.eventCenter.on('dnd:panel-dbclick', (args) => {
+    //   console.log('args', args);
+    // })
     lf.render();
+
   }, []);
 
   return (

--- a/packages/extension/src/components/dnd-panel/index.ts
+++ b/packages/extension/src/components/dnd-panel/index.ts
@@ -54,8 +54,11 @@ class DndPanel {
     el.className = shapeItem.className ? `lf-dnd-item ${shapeItem.className}` : 'lf-dnd-item';
     const shape = document.createElement('div');
     shape.className = 'lf-dnd-shape';
+    // if (typeof shapeItem.icon === 'string') {
     if (shapeItem.icon) {
       shape.style.backgroundImage = `url(${shapeItem.icon})`;
+    // } else {
+    //   shape.appendChild(shapeItem.icon);
     }
     el.appendChild(shape);
     if (shapeItem.label) {
@@ -76,6 +79,24 @@ class DndPanel {
         shapeItem.callback(this.lf, this.domContainer);
       }
     };
+    el.ondblclick = (e) => {
+      this.lf.graphModel.eventCenter.emit('dnd:panel-dbclick', {
+        e,
+        data: shapeItem,
+      })
+    }
+    el.onclick = (e) => {
+      this.lf.graphModel.eventCenter.emit('dnd:panel-click', {
+        e,
+        data: shapeItem,
+      })
+    }
+    el.oncontextmenu = (e) => {
+      this.lf.graphModel.eventCenter.emit('dnd:panel-contextmenu', {
+        e,
+        data: shapeItem,
+      })
+    }
     return el;
   }
 }


### PR DESCRIPTION
不改变`setPatternItems`的`options`，通过修改`DNDPanel`，给el添加事件，并触发`emit`，来实现dndPanel添加额外事件