### PR TITLE
feat: expand label and icon to dnd-penal

### DIFF
--- a/examples/src/pages/extension/components/dnd-panel/index.tsx
+++ b/examples/src/pages/extension/components/dnd-panel/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import LogicFlow from '@logicflow/core';
+import LogicFlow, { h } from '@logicflow/core';
 import { DndPanel, SelectionSelect } from '@logicflow/extension'
 import ExampleHeader from '../../../../components/example-header';
 const config = {
@@ -58,7 +58,29 @@ export default function DndPanelExample() {
         text: '结束',
         label: '结束节点',
         icon: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAYAAAH6ji2bAAAABGdBTUEAALGPC/xhBQAAA1BJREFUOBFtVE1IVUEYPXOf+tq40Y3vPcmFIdSjIorWoRG0ERWUgnb5FwVhYQSl72oUoZAboxKNFtWiwKRN0M+jpfSzqJAQclHo001tKkjl3emc8V69igP3znzfnO/M9zcDcKT67azmjYWTwl9Vn7Vumeqzj1DVb6cleQY4oAVnIOPb+mKAGxQmKI5CWNJ2aLPatxWa3aB9K7/fB+/Z0jUF6TmMlFLQqrkECWQzOZxYGjTlOl8eeKaIY5yHnFn486xBustDjWT6dG7pmjHOJd+33t0iitTPkK6tEvjxq4h2MozQ6WFSX/LkDUGfFwfhEZj1Auz/U4pyAi5Sznd7uKzznXeVHlI/Aywmk6j7fsUsEuCGADrWARXXwjxWQsUbIupDHJI7kF5dRktg0eN81IbiZXiTESic50iwS+t1oJgL83jAiBupLDCQqwziaWSoAFSeIR3P5Xv5az00wyIn35QRYTwdSYbz8pH8fxUUAtxnFvYmEmgI0wYXUXcCCSpeEVpXlsRhBnCEATxWylL9+EKCAYhe1NGstUa6356kS9NVvt3DU2fd+Wtbm/+lSbylJqsqkSm9CRhvoJVlvKPvF1RKY/FcPn5j4UfIMLn8D4UYb54BNsilTDXKnF4CfTobA0FpoW/LSp306wkXM+XaOJhZaFkcNM82ASNAWMrhrUbRfmyeI1FvRBTpN06WKxa9BK0o2E4Pd3zfBBEwPsv9sQBnmLVbLEIZ/Xe9LYwJu/Er17W6HYVBc7vmuk0xUQ+pqxdom5Fnp55SiytXLPYoMXNM4u4SNSCFWnrVIzKG3EGyMXo6n/BQOe+bX3FClY4PwydVhthOZ9NnS+ntiLh0fxtlUJHAuGaFoVmttpVMeum0p3WEXbcll94l1wM/gZ0Ccczop77VvN2I7TlsZCsuXf1WHvWEhjO8DPtyOVg2/mvK9QqboEth+7pD6NUQC1HN/TwvydGBARi9MZSzLE4b8Ru3XhX2PBxf8E1er2A6516o0w4sIA+lwURhAON82Kwe2iDAC1Watq4XHaGQ7skLcFOtI5lDxuM2gZe6WFIotPAhbaeYlU4to5cuarF1QrcZ/lwrLaCJl66JBocYZnrNlvm2+MBCTmUymPrYZVbjdlr/BxlMjmNmNI3SAAAAAElFTkSuQmCC',
-      }
+      },
+      // test
+      // {
+      //   type: 'circle',
+      //   text: '自定义icon',
+      //   label: h("span", null, '自定义label'),
+      //   icon: h("svg", {
+      //     width: 36,
+      //     height: 36,
+      //     viewBox: "0 0 36 36",
+      //     fill: "none"
+      //   }, [
+      //     h('rect', {
+      //       x: "0.5",
+      //       y: "6.5",
+      //       width: "35",
+      //       height: "23",
+      //       rx: "3.5",
+      //       fill: "white",
+      //       stroke: "black"
+      //     })
+      //   ])
+      // }
     ]);
     lf.render();
   }, []);

--- a/packages/core/src/index.tsx
+++ b/packages/core/src/index.tsx
@@ -1,6 +1,6 @@
 // 统一对外导出
 import { observer as mobxObserver } from 'mobx-react';
-import { h } from 'preact';
+import { h, render } from 'preact';
 import LogicFlow from './LogicFlow';
 
 import * as LogicFlowUtil from './util';
@@ -9,7 +9,7 @@ export function observer<P>(props: P) {
   return mobxObserver(props as any);
 }
 
-export { LogicFlow, h };
+export { LogicFlow, h, render };
 
 export { LogicFlowUtil };
 

--- a/packages/extension/src/components/dnd-panel/index.ts
+++ b/packages/extension/src/components/dnd-panel/index.ts
@@ -1,4 +1,4 @@
-import LogicFlow from '@logicflow/core';
+import LogicFlow, { render } from '@logicflow/core';
 
 type ShapeItem = {
   type?: string;
@@ -55,12 +55,20 @@ class DndPanel {
     const shape = document.createElement('div');
     shape.className = 'lf-dnd-shape';
     if (shapeItem.icon) {
-      shape.style.backgroundImage = `url(${shapeItem.icon})`;
+      if (typeof shapeItem.icon === 'string') {
+        shape.style.backgroundImage = `url(${shapeItem.icon})`;
+      } else if (typeof shapeItem.icon === 'object' && shapeItem.icon["$$typeof"]) {
+        render(shapeItem.icon, shape);
+      }
     }
     el.appendChild(shape);
     if (shapeItem.label) {
       const text = document.createElement('div');
-      text.innerText = shapeItem.label;
+      if (typeof shapeItem.label === 'string' || typeof shapeItem.label === 'number') {
+        text.innerText = shapeItem.label;
+      } else if (typeof shapeItem.label === 'object' && shapeItem.label["$$typeof"]) {
+        render(shapeItem.label, text);
+      }
       text.className = 'lf-dnd-text';
       el.appendChild(text);
     }


### PR DESCRIPTION
通过暴露`render`方法，在`dndpanel`中通过判断来区分`label`和`icon`是字符串还是`ReactNode`，如果是`ReactNode`使用`render`渲染并插入到容器中，通过此方法扩展也可实现`dndpanel`自定义事件