### PR TITLE
fix: twoPointDistance无法获取target参数

### DIFF
--- a/packages/core/src/model/edge/BaseEdgeModel.ts
+++ b/packages/core/src/model/edge/BaseEdgeModel.ts
@@ -196,7 +196,7 @@ class BaseEdgeModel implements IBaseModel {
     let minDistance;
     const sourceAnchors = getAnchors(sourceNode);
     sourceAnchors.forEach((anchor) => {
-      const distance = twoPointDistance(anchor, this.startPoint);
+      const distance = twoPointDistance(anchor, targetNode);
       if (minDistance === undefined) {
         minDistance = distance;
         position = anchor;
@@ -216,7 +216,7 @@ class BaseEdgeModel implements IBaseModel {
     let minDistance;
     const targetAnchors = getAnchors(targetNode);
     targetAnchors.forEach((anchor) => {
-      const distance = twoPointDistance(anchor, this.endPoint);
+      const distance = twoPointDistance(anchor, this.startPoint);
       if (minDistance === undefined) {
         minDistance = distance;
         position = anchor;


### PR DESCRIPTION
文档示例无法显示 [边上插入节点 InsertNodeInPolyline](http://logic-flow.org/guide/extension/extension-insert-node-in-polyline.html#%E5%8A%9F%E8%83%BD)
并报错：TypeError: Cannot read properties of null (reading 'x')

**原因：**
**twoPointDistance无法获取target参数**

<img width="763" alt="image" src="https://user-images.githubusercontent.com/75007029/209506034-76b27877-adac-4900-8eef-65e78db6da3f.png">


计算两个节点相连是起点位置：getBeginAnchor
和计算两个节点相连是终点位置：getEndAnchor 
传入参数target 为null
<img width="724" alt="image" src="https://user-images.githubusercontent.com/75007029/209506478-098a622e-0688-4b75-8f80-8a72e52a4333.png">
<img width="657" alt="image" src="https://user-images.githubusercontent.com/75007029/209506586-035f11c6-2b69-49df-bcfa-84efb5d58843.png">

