### PR TITLE
anchor的drop和dragend事件的参数传递优化成event对像不嵌套在e对像下

### DIFF
--- a/packages/core/index.html
+++ b/packages/core/index.html
@@ -923,6 +923,12 @@
         lf.on('edge:exchange-node',({data})=> {
           console.log('edge:exchange-node', data)
         })
+        lf.on('anchor:drop',(data) => {
+          console.log('anchor:drop', data)
+        })
+        lf.on('anchor:dragend',(data) => {
+          console.log('anchor:dragend', data)
+        })
         // lf.on('node:mousemove',()=> {
         //   // console.log('nodemove')
         // })

--- a/packages/core/src/view/Anchor.tsx
+++ b/packages/core/src/view/Anchor.tsx
@@ -170,7 +170,7 @@ class Anchor extends Component<IProps, IState> {
       nodeModel,
     });
   };
-  onDragEnd = (event) => {
+  onDragEnd = ({ event }) => {
     if (this.t) {
       cancelRaf(this.t);
     }


### PR DESCRIPTION
之前是：
```javascript
{
   e: {
       event: EventObject
   },
   data: ....
}
```

优化后是：
```javascript
{
  e: EventObject,
  data: ...
}
```