### PR TITLE
export ElementState ModelType ElementType EventType from constant.ts

### DIFF
--- a/packages/core/src/index.tsx
+++ b/packages/core/src/index.tsx
@@ -18,5 +18,6 @@ export * from './view';
 export * from './model';
 export * from './keyboard';
 export * from './options';
+export { ElementState, ModelType, ElementType, EventType } from './constant/constant';
 
 export default LogicFlow;


### PR DESCRIPTION
将core/constant/constant.ts中定义的ElementState, ModelType, ElementType, EventType导出，方便第三方代码能使用其中定义的常量