### PR TITLE
Update json2xml.ts

### DIFF
--- a/packages/extension/src/bpmn-adapter/json2xml.ts
+++ b/packages/extension/src/bpmn-adapter/json2xml.ts
@@ -73,7 +73,7 @@ function toXml(obj: string | any[] | Object, name: string, depth: number) {
         attributes +
         (children !== "" ? `>${children}${tn + frontSpace}</${name}>` : " />");
     } else {
-      str += tn + frontSpace + `<$${name}>${obj.toString()}</${name}>`;
+      str += tn + frontSpace + `<${name}>${obj.toString()}</${name}>`;
     }
   }
 


### PR DESCRIPTION
修复使用BpmnXmlAdapter插件后导出没有属性和子标签的标签（如bpmn:outgoing）时，标签名称前带有$符号的问题
问题复现案例如图
![image](https://user-images.githubusercontent.com/39972632/236190624-f2f23670-3919-49bf-917b-a58be029320d.png)
