### PR TITLE
feat: getTargetAnchor方法增加AdjustType类型参数方便确定是获取前序节点还是后序节点的锚点

### DIFF
--- a/packages/core/src/model/node/BaseNodeModel.ts
+++ b/packages/core/src/model/node/BaseNodeModel.ts
@@ -26,6 +26,7 @@ import { formatData } from '../../util/compatible';
 import { getClosestAnchor, pickNodeConfig } from '../../util/node';
 import { getZIndex } from '../../util/zIndex';
 import { BaseEdgeModel } from '../edge';
+import { AdjustType } from '../../view/edge/AdjustPoint';
 
 export type ConnectRule = {
   message: string;
@@ -437,7 +438,7 @@ export default class BaseNodeModel implements IBaseNodeModel {
    * @overridable 子类重写此方法获取手动连接边到节点时，需要连接的锚点
    * 手动连接边到节点时，需要连接的锚点
    */
-  public getTargetAnchor(position: Point): AnchorInfo {
+  public getTargetAnchor(position: Point, type: AdjustType): AnchorInfo {
     return getClosestAnchor(position, this);
   }
 

--- a/packages/core/src/util/node.ts
+++ b/packages/core/src/util/node.ts
@@ -15,6 +15,7 @@ import { isInSegment } from '../algorithm/edge';
 import { SegmentDirection } from '../constant/constant';
 import { getBytesLength } from './edge';
 import { GraphModel } from '..';
+import { AdjustType } from '../view/edge/AdjustPoint';
 
 /* 获取所有锚点 */
 export const getAnchors = (data): Point[] => {
@@ -31,14 +32,15 @@ type NodeContaint = {
 };
 
 /* 手动边时获取目标节点的信息：目标节点，目标节点的锚点index以及坐标 */
-export const targetNodeInfo = (position: Point, graphModel: GraphModel): NodeContaint => {
+export const targetNodeInfo = (position: Point, graphModel: GraphModel,
+  type: AdjustType): NodeContaint => {
   const { nodes } = graphModel;
   let nodeInfo;
   for (let i = nodes.length - 1; i >= 0; i--) {
     const targetNode = nodes[i];
     const inNode = isInNodeBbox(position, targetNode);
     if (inNode) {
-      const anchorInfo = targetNode.getTargetAnchor(position);
+      const anchorInfo = targetNode.getTargetAnchor(position, type);
       if (anchorInfo) { // 不能连接到没有锚点的节点
         const currentNodeInfo = {
           node: targetNode,

--- a/packages/core/src/view/Anchor.tsx
+++ b/packages/core/src/view/Anchor.tsx
@@ -10,6 +10,7 @@ import GraphModel from '../model/GraphModel';
 import { AnchorConfig } from '../type';
 import { BaseNode } from './node';
 import { cancelRaf, createRaf } from '../util/raf';
+import { AdjustType } from './edge/AdjustPoint';
 
 type TargetNodeId = string;
 
@@ -203,7 +204,7 @@ class Anchor extends Component<IProps, IState> {
     /* 创建边 */
     const { edgeType } = graphModel;
     const { endX, endY, dragging } = this.state;
-    const info = targetNodeInfo({ x: endX, y: endY }, graphModel);
+    const info = targetNodeInfo({ x: endX, y: endY }, graphModel, AdjustType.TARGET);
     // 为了保证鼠标离开的时候，将上一个节点状态重置为正常状态。
     if (this.preTargetNode && this.preTargetNode.state !== ElementState.DEFAULT) {
       this.preTargetNode.setElementState(ElementState.DEFAULT);
@@ -255,7 +256,7 @@ class Anchor extends Component<IProps, IState> {
   };
   moveAnchorEnd(endX: number, endY: number) {
     const { graphModel, nodeModel, anchorData } = this.props;
-    const info = targetNodeInfo({ x: endX, y: endY }, graphModel);
+    const info = targetNodeInfo({ x: endX, y: endY }, graphModel, AdjustType.TARGET);
     if (info) {
       const targetNode = info.node;
       const anchorId = info.anchor.id;

--- a/packages/core/src/view/edge/AdjustPoint.tsx
+++ b/packages/core/src/view/edge/AdjustPoint.tsx
@@ -28,7 +28,7 @@ interface OldEdge {
   pointsList: Point[];
 }
 
-enum AdjustType {
+export enum AdjustType {
   SOURCE = 'SOURCE',
   TARGET = 'TARGET',
 }
@@ -105,7 +105,7 @@ export default class AdjustPoint extends Component<IProps, IState> {
     });
     // 调整过程中实时更新路径
     const { edgeModel } = this.props;
-    const info = targetNodeInfo({ x: endX, y: endY }, graphModel);
+    const info = targetNodeInfo({ x: endX, y: endY }, graphModel, type);
     // 如果一定的坐标能够找到目标节点，预结算当前节点与目标节点的路径进行展示
     if (info && info.node && this.isAllowAdjust(info).pass) {
       let params;
@@ -149,7 +149,7 @@ export default class AdjustPoint extends Component<IProps, IState> {
       // 拖拽AdjustPoint时不修改edgeModel.isHitable，避免偶尔会出现边不能点击问题(https://github.com/didi/LogicFlow/issues/974)
       // edgeModel.isHitable = true;
       const { endX, endY, dragging } = this.state;
-      const info = targetNodeInfo({ x: endX, y: endY }, graphModel);
+      const info = targetNodeInfo({ x: endX, y: endY }, graphModel, type);
       // 没有dragging就结束边
       if (!dragging) return;
       // 如果找到目标节点，删除老边，创建新边


### PR DESCRIPTION
为了让布局更好看，可能需要限制只能从前一个节点的右侧锚点链接到下一个节点的左侧锚点。
在调整边的锚点时，需要知道是调整的左侧还是右侧锚点，还好确定目前节点的锚点。
比如调整边的右侧锚点，getTargetAnchor需要返回节点的左侧锚点；调整边的左侧锚点，getTargetAnchor需要返回节点的右侧锚点；