### PR TITLE
fix(core): prevent isSilentMode=true from calling repeatedly(#1180)

### DIFF
--- a/packages/core/src/model/EditConfigModel.ts
+++ b/packages/core/src/model/EditConfigModel.ts
@@ -147,7 +147,10 @@ export default class EditConfigModel {
       assign(conf, this.defaultConfig);
     }
     // 如果不传，默认undefined表示非静默模式
-    if (isSilentMode === true) {
+    if (isSilentMode === true && isSilentMode !== this.isSilentMode) {
+      // https://github.com/didi/LogicFlow/issues/1180
+      // 如果重复调用isSilentMode=true多次，会导致this.defaultConfig状态保存错误：保存为修改之后的Config
+      // 因此需要阻止重复赋值为true，使用config.isSilentMode !== this.isSilentMode
       const silentConfig = pick(SilentConfig, keys);
       // 在修改之前，
       this.defaultConfig = {


### PR DESCRIPTION
close [https://github.com/didi/LogicFlow/issues/1180](https://github.com/didi/LogicFlow/issues/1180)

**问题发生原因**：
1. 每次`isSilentMode=true`的时候，都会进行当前状态`config`的保存
2. 当触发第二次`isSilentMode=true`时，会进行`isSilentMode=true`状态的保存（实际上应该保存`isSilentMode=false`->`isSilentMode=true`时的当前状态），当切换到`isSilentMode=false`时，会进行状态的回滚（但是此时`this.defaultConfig`已经错误，为`isSilentMode=true`时的状态）

**解决方法**：
1. 检测到`isSilentMode=true`重复赋值时，进行`this.defaultConfig`的赋值阻止