### PR TITLE
fix: 修正Control移除item不正确的问题

### DIFF
--- a/packages/extension/src/components/control/index.ts
+++ b/packages/extension/src/components/control/index.ts
@@ -82,7 +82,7 @@ class Control {
   }
   removeItem(key) {
     const index = this.controlItems.findIndex((item) => item.key === key);
-    return this.controlItems.splice(index, 1)[0];
+    return index == -1 ? null : this.controlItems.splice(index, 1)[0];
   }
   private getControlTool(): HTMLElement {
     const NORMAL = 'lf-control-item';


### PR DESCRIPTION
当移除不存在的key时，会将最后一项移除。这样存在问题。