### PR TITLE
fix(core): improve the appearance of Bezier curve arrows.(#951)

### DIFF
--- a/packages/core/index.html
+++ b/packages/core/index.html
@@ -501,14 +501,14 @@
           },
           grid: true,
           edgeTextDraggable: true,
-          // edgeType: 'bezier',
+          edgeType: 'bezier',
           // 全局自定义id
-          edgeGenerator: (sourceNode, targetNode, currentEdge) => {
-            // 起始节点类型 rect 时使用 自定义的边 custom-edge
-            if (sourceNode.type === 'rect') return 'bezier'
-            if (currentEdge) return currentEdge.type
-            return 'polyline'
-          },
+          // edgeGenerator: (sourceNode, targetNode, currentEdge) => {
+          //   // 起始节点类型 rect 时使用 自定义的边 custom-edge
+          //   if (sourceNode.type === 'rect') return 'bezier'
+          //   if (currentEdge) return currentEdge.type
+          //   return 'polyline'
+          // },
           idGenerator(type) {
             return type + '_' + Math.random()
           }
@@ -572,14 +572,14 @@
             rect: {
               width: 200,
               height: 40,
+            },
+            arrow: {
+              offset: 4, // 箭头长度
+              verticalLength: 2, // 箭头垂直于边的距离
             }
-            // arrow: {
-            //   offset: 4, // 箭头长度
-            //   verticalLength: 2, // 箭头垂直于边的距离
-            // }
           }
         );
-        lf.setDefaultEdgeType('polyline');
+        // lf.setDefaultEdgeType('polyline');
       }
     </script>
 

--- a/packages/core/src/util/edge.ts
+++ b/packages/core/src/util/edge.ts
@@ -837,11 +837,11 @@ const getBezierPoint = (positionStr: string): Point => {
   };
 };
 // 根据bezier曲线path求出结束切线的两点坐标
-export const getEndTangent = (path: string): Point[] => {
-  const bezierPoints = getBezierPoints(path);
-  const [p1, cp1, cp2, p2] = bezierPoints;
-  const start = sampleCubic(p1, cp1, cp2, p2);
-  return [start, bezierPoints[3]];
+export const getEndTangent = (pointsList, offset): Point[] => {
+  // const bezierPoints = getBezierPoints(path);
+  const [p1, cp1, cp2, p2] = pointsList;
+  const start = sampleCubic(p1, cp1, cp2, p2, offset);
+  return [start, pointsList[3]];
 };
 
 /**

--- a/packages/core/src/view/edge/BezierEdge.tsx
+++ b/packages/core/src/view/edge/BezierEdge.tsx
@@ -60,8 +60,12 @@ export default class BezierEdge extends BaseEdge {
   getArrowInfo(): ArrowInfo {
     const { model } = this.props;
     const { hover } = this.state as IEdgeState;
-    const { path, isSelected } = model as BezierEdgeModel;
-    const [ePre, end] = getEndTangent(path);
+    const { isSelected } = model as BezierEdgeModel;
+    const { offset } = model.getArrowStyle();
+    const points = model.pointsList.map((point) => (
+      { x: point.x, y: point.y }
+    ));
+    const [ePre, end] = getEndTangent(points, offset);
     const arrowInfo = {
       start: ePre,
       end,
@@ -73,7 +77,10 @@ export default class BezierEdge extends BaseEdge {
 
   getLastTwoPoints(): any[] {
     const { model } = this.props;
-    const { path } = model as BezierEdgeModel;
-    return getEndTangent(path);
+    const { offset } = model.getArrowStyle();
+    const points = model.pointsList.map((point) => (
+      { x: point.x, y: point.y }
+    ));
+    return getEndTangent(points, offset);
   }
 }


### PR DESCRIPTION
close https://github.com/didi/LogicFlow/issues/951

## 问题发生原因
由于贝塞尔曲线的箭头之前是直接使用0.95采样点和终点作为箭头的方向，当遇两个节点距离过远且控制点太短的时，就会出现箭头的方向和曲线差别很大的情况。

## 解决办法
从0.98采样点开始，计算到0.5，取第一个满足和终点距离大于offset的采样点。通过这两个点计算出来的方向能保证箭头垂点和曲线尽量重合。经过统计在大多数情况下只需要计算2-5既可以得出采样点（曲线越短，计算次数越多），所以性能影响不大。

