### PR TITLE
feat: anchor dragend事件参数增加edgeModel

### DIFF
--- a/packages/core/src/view/Anchor.tsx
+++ b/packages/core/src/view/Anchor.tsx
@@ -202,7 +202,7 @@ class Anchor extends Component<IProps, IState> {
     return customTrajectory;
   }
 
-  checkEnd: (event: string) => BaseEdgeModel | null = (event) => {
+  checkEnd: (event: MouseEvent) => BaseEdgeModel | null = (event) => {
     const {
       graphModel, nodeModel, anchorData: { x, y, id },
     } = this.props;

--- a/packages/core/src/view/Anchor.tsx
+++ b/packages/core/src/view/Anchor.tsx
@@ -189,16 +189,12 @@ class Anchor extends Component<IProps, IState> {
     const {
       graphModel, nodeModel, anchorData,
     } = this.props;
-
-    const emittedData = {
+    graphModel.eventCenter.emit(EventType.ANCHOR_DRAGEND, {
       data: anchorData,
       e: event,
       nodeModel,
-    };
-    if (edgeModel) {
-      Object.assign(emittedData, { edgeModel });
-    }
-    graphModel.eventCenter.emit(EventType.ANCHOR_DRAGEND, emittedData);
+      edgeModel,
+    });
   };
 
   get customTrajectory() {
@@ -257,12 +253,12 @@ class Anchor extends Component<IProps, IState> {
         });
         return edgeModel;
       }
-
       const nodeData = targetNode.getData();
       graphModel.eventCenter.emit(EventType.CONNECTION_NOT_ALLOWED, {
         data: nodeData,
         msg: targetMsg || sourceMsg,
       });
+      return null;
     }
   };
   moveAnchorEnd(endX: number, endY: number) {


### PR DESCRIPTION
anchor:dragend 事件参数增加 edgeModel 参数，便于用户在事件中区分锚点连线是否连接到一个已有节点。

用于实现一些功能，例如从某个节点拖出连线，释放鼠标时在释放位置自动创建新节点，此时需要判断鼠标释放时是否已经连接到已存在的节点。