### PR TITLE
add draggable range for graph(#1337)

### DIFF
--- a/packages/core/src/LogicFlow.tsx
+++ b/packages/core/src/LogicFlow.tsx
@@ -131,11 +131,13 @@ export default class LogicFlow {
       this.snaplineModel = new SnaplineModel(this.graphModel);
       snaplineTool(this.graphModel.eventCenter, this.snaplineModel);
     }
-    // 先初始化默认内置快捷键
-    initDefaultShortcut(this, this.graphModel);
-    // 然后再初始化自定义快捷键，自定义快捷键可以覆盖默认快捷键.
-    // 插件最后初始化。方便插件强制覆盖内置快捷键
-    this.keyboard.initShortcuts();
+    if (!this.options.isSilentMode) {
+      // 先初始化默认内置快捷键
+      initDefaultShortcut(this, this.graphModel);
+      // 然后再初始化自定义快捷键，自定义快捷键可以覆盖默认快捷键.
+      // 插件最后初始化。方便插件强制覆盖内置快捷键
+      this.keyboard.initShortcuts();
+    }
     // init 放到最后
     this.defaultRegister();
     this.installPlugins(options.disabledPlugins);

--- a/packages/core/src/model/EditConfigModel.ts
+++ b/packages/core/src/model/EditConfigModel.ts
@@ -15,9 +15,13 @@ export interface EditConfigInterface {
    */
   stopScrollGraph?: boolean;
   /**
-   * 禁止拖动画布
+   * 禁止拖动画布，默认为false
+   * true：完全禁止移动
+   * vertical： 禁止垂直方向拖动
+   * horizontal：禁止水平方向拖动
+   * [number, number, number, number]：[minX, minY, maxX, maxY] 画布可拖动范围
    */
-  stopMoveGraph?: boolean;
+  stopMoveGraph?: boolean | 'vertical' | 'horizontal' | [number, number, number, number];
   /**
    * 允许调整边
    */

--- a/packages/core/src/model/GraphModel.ts
+++ b/packages/core/src/model/GraphModel.ts
@@ -155,7 +155,7 @@ class GraphModel {
     this.rootEl = container;
     this.editConfigModel = new EditConfigModel(options);
     this.eventCenter = new EventEmitter();
-    this.transformModel = new TransformModel(this.eventCenter);
+    this.transformModel = new TransformModel(this.eventCenter, options);
     this.theme = updateTheme(options.style);
     this.edgeType = options.edgeType || 'polyline';
     this.width = options.width;

--- a/packages/core/src/model/TransformModel.ts
+++ b/packages/core/src/model/TransformModel.ts
@@ -16,9 +16,20 @@ export interface TransformInterface {
   zoom: (isZoomOut: ZoomParam) => string;
   HtmlPointToCanvasPoint: (point: PointTuple) => PointTuple;
   CanvasPointToHtmlPoint: (point: PointTuple) => PointTuple;
-  moveCanvasPointByHtml: (point: PointTuple, x: number, y: number) => PointTuple;
+  moveCanvasPointByHtml: (
+    point: PointTuple,
+    x: number,
+    y: number,
+  ) => PointTuple;
   getTransformStyle: () => { transform: string };
 }
+
+const translateLimitsMap = {
+  false: [-Infinity, -Infinity, Infinity, Infinity],
+  true: [0, 0, 0, 0],
+  vertical: [Infinity, 0, -Infinity, 0],
+  horizontal: [0, Infinity, 0, -Infinity],
+};
 
 export default class TransformModel implements TransformInterface {
   MINI_SCALE_SIZE = 0.2;
@@ -31,8 +42,14 @@ export default class TransformModel implements TransformInterface {
   @observable TRANSLATE_Y = 0;
   @observable ZOOM_SIZE = 0.04;
   eventCenter: EventEmitter;
-  constructor(eventCenter) {
+  translateLimitMinX: number;
+  translateLimitMinY: number;
+  translateLimitMaxX: number;
+  translateLimitMaxY: number;
+  constructor(eventCenter, options) {
     this.eventCenter = eventCenter;
+    const { stopMoveGraph = false } = options;
+    this.updateTranslateLimits(stopMoveGraph);
   }
   setZoomMiniSize(size: number): void {
     this.MINI_SCALE_SIZE = size;
@@ -47,7 +64,10 @@ export default class TransformModel implements TransformInterface {
    * @param param0 HTML点
    */
   HtmlPointToCanvasPoint([x, y]: PointTuple): PointTuple {
-    return [(x - this.TRANSLATE_X) / this.SCALE_X, (y - this.TRANSLATE_Y) / this.SCALE_Y];
+    return [
+      (x - this.TRANSLATE_X) / this.SCALE_X,
+      (y - this.TRANSLATE_Y) / this.SCALE_Y,
+    ];
   }
 
   /**
@@ -55,7 +75,10 @@ export default class TransformModel implements TransformInterface {
    * @param param0 HTML点
    */
   CanvasPointToHtmlPoint([x, y]: PointTuple): PointTuple {
-    return [x * this.SCALE_X + this.TRANSLATE_X, y * this.SCALE_Y + this.TRANSLATE_Y];
+    return [
+      x * this.SCALE_X + this.TRANSLATE_X,
+      y * this.SCALE_Y + this.TRANSLATE_Y,
+    ];
   }
 
   /**
@@ -65,7 +88,11 @@ export default class TransformModel implements TransformInterface {
    * @param directionX x轴距离
    * @param directionY y轴距离
    */
-  moveCanvasPointByHtml([x, y]: PointTuple, directionX: number, directionY: number): PointTuple {
+  moveCanvasPointByHtml(
+    [x, y]: PointTuple,
+    directionX: number,
+    directionY: number,
+  ): PointTuple {
     return [x + directionX / this.SCALE_X, y + directionY / this.SCALE_Y];
   }
 
@@ -81,7 +108,14 @@ export default class TransformModel implements TransformInterface {
    * 基于当前的缩放，获取画布渲染样式transform值
    */
   getTransformStyle() {
-    const matrixString = [this.SCALE_X, this.SKEW_Y, this.SKEW_X, this.SCALE_Y, this.TRANSLATE_X, this.TRANSLATE_Y].join(',');
+    const matrixString = [
+      this.SCALE_X,
+      this.SKEW_Y,
+      this.SKEW_X,
+      this.SCALE_Y,
+      this.TRANSLATE_X,
+      this.TRANSLATE_Y,
+    ].join(',');
     return {
       transform: `matrix(${matrixString})`,
     };
@@ -132,7 +166,7 @@ export default class TransformModel implements TransformInterface {
     });
   }
   @action
-  resetZoom() : void {
+  resetZoom(): void {
     this.SCALE_X = 1;
     this.SCALE_Y = 1;
     this.emitGraphTransform('resetZoom');
@@ -140,8 +174,12 @@ export default class TransformModel implements TransformInterface {
 
   @action
   translate(x: number, y: number) {
-    this.TRANSLATE_X += x;
-    this.TRANSLATE_Y += y;
+    this.TRANSLATE_X + x <= this.translateLimitMaxX
+      && this.TRANSLATE_X + x >= this.translateLimitMinX
+      && (this.TRANSLATE_X += x);
+    this.TRANSLATE_Y + y <= this.translateLimitMaxY
+      && this.TRANSLATE_Y + y >= this.translateLimitMinY
+      && (this.TRANSLATE_Y += y);
     this.emitGraphTransform('translate');
   }
 
@@ -159,5 +197,25 @@ export default class TransformModel implements TransformInterface {
     this.TRANSLATE_X += deltaX;
     this.TRANSLATE_Y += deltaY;
     this.emitGraphTransform('focusOn');
+  }
+  /**
+   * 更新画布可以移动范围
+   */
+  updateTranslateLimits(limit: boolean | 'vertical' | 'horizontal' | [number, number, number, number]) {
+    if (Array.isArray(limit) && limit.length === 4) {
+      [
+        this.translateLimitMinX,
+        this.translateLimitMinY,
+        this.translateLimitMaxX,
+        this.translateLimitMaxY,
+      ] = limit;
+    } else {
+      [
+        this.translateLimitMinX,
+        this.translateLimitMinY,
+        this.translateLimitMaxX,
+        this.translateLimitMaxY,
+      ] = translateLimitsMap[limit.toString()];
+    }
   }
 }

--- a/packages/core/src/model/TransformModel.ts
+++ b/packages/core/src/model/TransformModel.ts
@@ -174,12 +174,14 @@ export default class TransformModel implements TransformInterface {
 
   @action
   translate(x: number, y: number) {
-    this.TRANSLATE_X + x <= this.translateLimitMaxX
-      && this.TRANSLATE_X + x >= this.translateLimitMinX
-      && (this.TRANSLATE_X += x);
-    this.TRANSLATE_Y + y <= this.translateLimitMaxY
-      && this.TRANSLATE_Y + y >= this.translateLimitMinY
-      && (this.TRANSLATE_Y += y);
+    if (this.TRANSLATE_X + x <= this.translateLimitMaxX
+      && this.TRANSLATE_X + x >= this.translateLimitMinX) {
+      this.TRANSLATE_X += x;
+    }
+    if (this.TRANSLATE_Y + y <= this.translateLimitMaxY
+      && this.TRANSLATE_Y + y >= this.translateLimitMinY) {
+      this.TRANSLATE_Y += y;
+    }
     this.emitGraphTransform('translate');
   }
 
@@ -202,20 +204,14 @@ export default class TransformModel implements TransformInterface {
    * 更新画布可以移动范围
    */
   updateTranslateLimits(limit: boolean | 'vertical' | 'horizontal' | [number, number, number, number]) {
-    if (Array.isArray(limit) && limit.length === 4) {
-      [
-        this.translateLimitMinX,
-        this.translateLimitMinY,
-        this.translateLimitMaxX,
-        this.translateLimitMaxY,
-      ] = limit;
-    } else {
-      [
-        this.translateLimitMinX,
-        this.translateLimitMinY,
-        this.translateLimitMaxX,
-        this.translateLimitMaxY,
-      ] = translateLimitsMap[limit.toString()];
-    }
+    const boundary = Array.isArray(limit) && limit.length === 4
+      ? limit
+      : translateLimitsMap[limit.toString()];
+    [
+      this.translateLimitMinX,
+      this.translateLimitMinY,
+      this.translateLimitMaxX,
+      this.translateLimitMaxY,
+    ] = boundary;
   }
 }

--- a/packages/core/src/model/TransformModel.ts
+++ b/packages/core/src/model/TransformModel.ts
@@ -27,8 +27,8 @@ export interface TransformInterface {
 const translateLimitsMap = {
   false: [-Infinity, -Infinity, Infinity, Infinity],
   true: [0, 0, 0, 0],
-  vertical: [Infinity, 0, -Infinity, 0],
-  horizontal: [0, Infinity, 0, -Infinity],
+  vertical: [-Infinity, 0, Infinity, 0],
+  horizontal: [0, -Infinity, 0, Infinity],
 };
 
 export default class TransformModel implements TransformInterface {

--- a/packages/core/src/view/behavior/DnD.ts
+++ b/packages/core/src/view/behavior/DnD.ts
@@ -32,8 +32,10 @@ export default class Dnd {
   }
 
   startDrag(nodeConfig: NewNodeConfig) {
-    this.nodeConfig = nodeConfig;
-    window.document.addEventListener('mouseup', this.stopDrag);
+    if (!this.lf.options.isSilentMode) {
+      this.nodeConfig = nodeConfig;
+      window.document.addEventListener('mouseup', this.stopDrag);
+    }
   }
   stopDrag = () => {
     this.nodeConfig = null;

--- a/packages/core/src/view/overlay/CanvasOverlay.tsx
+++ b/packages/core/src/view/overlay/CanvasOverlay.tsx
@@ -53,7 +53,7 @@ class CanvasOverlay extends Component<IProps, IState> {
         editConfigModel,
       },
     } = this.props;
-    if (editConfigModel.stopMoveGraph) {
+    if (editConfigModel.stopMoveGraph === true) {
       return;
     }
     transformModel.translate(deltaX, deltaY);
@@ -135,7 +135,7 @@ class CanvasOverlay extends Component<IProps, IState> {
     const target = ev.target as HTMLElement;
     const isFrozenElement = !editConfigModel.adjustEdge && !editConfigModel.adjustNodePosition;
     if (target.getAttribute('name') === 'canvas-overlay' || isFrozenElement) {
-      if (!editConfigModel.stopMoveGraph) {
+      if (editConfigModel.stopMoveGraph !== true) {
         this.stepDrag.setStep(gridSize * SCALE_X);
         this.stepDrag.handleMouseDown(ev);
       } else {

--- a/packages/extension/src/components/menu/index.ts
+++ b/packages/extension/src/components/menu/index.ts
@@ -28,19 +28,23 @@ class Menu {
   private __currentData: any;
   static pluginName = 'menu';
   constructor({ lf }) {
-    this.__menuDOM = document.createElement('ul');
     this.lf = lf;
-    this.menuTypeMap = new Map();
-    this.init();
-    this.lf.setMenuConfig = (config) => {
-      this.setMenuConfig(config);
-    };
-    this.lf.addMenuConfig = (config) => {
-      this.addMenuConfig(config);
-    };
-    this.lf.setMenuByType = (config) => {
-      this.setMenuByType(config);
-    };
+    const { options: { isSilentMode } } = lf;
+    if (!isSilentMode) {
+      this.__menuDOM = document.createElement('ul');
+
+      this.menuTypeMap = new Map();
+      this.init();
+      this.lf.setMenuConfig = (config) => {
+        this.setMenuConfig(config);
+      };
+      this.lf.addMenuConfig = (config) => {
+        this.addMenuConfig(config);
+      };
+      this.lf.setMenuByType = (config) => {
+        this.setMenuByType(config);
+      };
+    }
   }
   /**
    * 初始化设置默认内置菜单栏


### PR DESCRIPTION
feat:
1. add draggable range for graph #1337 
```typescript
 stopMoveGraph?: boolean | 'vertical' | 'horizontal' | [number, number, number, number];  // [minX, minY, maxX, maxY]
// as: 
//  false: [-Infinity, -Infinity, Infinity, Infinity],
//  true: [0, 0, 0, 0],
//  vertical: [Infinity, 0, -Infinity, 0]
//  horizontal: [0, Infinity, 0, -Infinity]

// for example:
stopMoveGraph: [-20, -50, 40, 100]
// as:
//  -50 <= translate of the graph in y-axis < = 100
//  -20 <= translate of the graph in x-axis < = 40
``` 

fix:
1. make graph read-only after setting silent mode #1335 