### PR TITLE
feat: 支持自定义从锚点拖出的连线路径

### DIFF
--- a/docs/api/logicFlowApi.md
+++ b/docs/api/logicFlowApi.md
@@ -49,6 +49,7 @@ const lf = new LogicFlow(options: Options)
 |plugins|Array| -|-|当前LogicFlow实例加载的插件，不传则采用全局插件。|
 |autoExpand|boolean| -|-|节点拖动靠近画布边缘时是否自动扩充画布, 默认true。 注意，如果出现拖动节点到某个位置画布就不停滚动的问题，是因为初始化画布的时候宽高有问题。如果画布宽高不定，建议关闭autoExpand。|
 |overlapMode|number|-|-|元素重合的堆叠模式，默认为连线在下、节点在上，选中元素在最上面。可以设置为1，表示自增模式（作图工具场景常用）。|
+|getAnchorLine|function|-|-|自定义锚点拖出连接线的路径|
 
 ### `background`
 
@@ -145,6 +146,36 @@ const lf = new LogicFlow({
 
 - 在编辑模式下，默认开启对齐线，将snapline设置为false，关闭对齐线。
 - 在不可编辑模式下，对齐线关闭。
+
+### `getAnchorLine`
+
+将连线过程的路径设置为横向控制点的贝塞尔曲线
+
+```js
+import { h } from '@logicflow/core'
+
+const lf = new LogicFlow({
+  getAnchorLine({ sourcePoint, targetPoint, ...props }) {
+    const d = getBezierPath([sourcePoint, targetPoint]);
+    return h('path', {
+      fill: 'transparent',
+      d,
+      ...props,
+    });
+  }
+})
+
+/* 根据起点和终点获取贝塞尔曲线的path */
+function getBezierPath(points, offset=100) {
+  const [start, end] = points;
+  const sNext = { x: start.x + offset, y: start.y };
+  const ePre = { x: end.x - offset, y: end.y };
+  return `M ${start.x} ${start.y}
+    C ${sNext.x} ${sNext.y},
+    ${ePre.x} ${ePre.y},
+    ${end.x} ${end.y}`;
+}
+```
 
 ## register
 

--- a/docs/api/logicFlowApi.md
+++ b/docs/api/logicFlowApi.md
@@ -49,7 +49,7 @@ const lf = new LogicFlow(options: Options)
 |plugins|Array| -|-|当前LogicFlow实例加载的插件，不传则采用全局插件。|
 |autoExpand|boolean| -|-|节点拖动靠近画布边缘时是否自动扩充画布, 默认true。 注意，如果出现拖动节点到某个位置画布就不停滚动的问题，是因为初始化画布的时候宽高有问题。如果画布宽高不定，建议关闭autoExpand。|
 |overlapMode|number|-|-|元素重合的堆叠模式，默认为连线在下、节点在上，选中元素在最上面。可以设置为1，表示自增模式（作图工具场景常用）。|
-|getAnchorLine|function|-|-|自定义锚点拖出连接线的路径|
+|getTrajectory|function|-|-|自定义锚点拖出连接线的路径|
 
 ### `background`
 
@@ -147,7 +147,7 @@ const lf = new LogicFlow({
 - 在编辑模式下，默认开启对齐线，将snapline设置为false，关闭对齐线。
 - 在不可编辑模式下，对齐线关闭。
 
-### `getAnchorLine`
+### `getTrajectory`
 
 将连线过程的路径设置为横向控制点的贝塞尔曲线
 
@@ -155,7 +155,7 @@ const lf = new LogicFlow({
 import { h } from '@logicflow/core'
 
 const lf = new LogicFlow({
-  getAnchorLine({ sourcePoint, targetPoint, ...props }) {
+  getTrajectory({ sourcePoint, targetPoint, ...props }) {
     const d = getBezierPath([sourcePoint, targetPoint]);
     return h('path', {
       fill: 'transparent',

--- a/docs/api/logicFlowApi.md
+++ b/docs/api/logicFlowApi.md
@@ -49,7 +49,7 @@ const lf = new LogicFlow(options: Options)
 |plugins|Array| -|-|当前LogicFlow实例加载的插件，不传则采用全局插件。|
 |autoExpand|boolean| -|-|节点拖动靠近画布边缘时是否自动扩充画布, 默认true。 注意，如果出现拖动节点到某个位置画布就不停滚动的问题，是因为初始化画布的时候宽高有问题。如果画布宽高不定，建议关闭autoExpand。|
 |overlapMode|number|-|-|元素重合的堆叠模式，默认为连线在下、节点在上，选中元素在最上面。可以设置为1，表示自增模式（作图工具场景常用）。|
-|getTrajectory|function|-|-|自定义锚点拖出连接线的路径|
+|customTrajectory|function|-|-|自定义锚点拖出连接线的路径|
 
 ### `background`
 
@@ -147,7 +147,7 @@ const lf = new LogicFlow({
 - 在编辑模式下，默认开启对齐线，将snapline设置为false，关闭对齐线。
 - 在不可编辑模式下，对齐线关闭。
 
-### `getTrajectory`
+### `customTrajectory`
 
 将连线过程的路径设置为横向控制点的贝塞尔曲线
 
@@ -155,7 +155,7 @@ const lf = new LogicFlow({
 import { h } from '@logicflow/core'
 
 const lf = new LogicFlow({
-  getTrajectory({ sourcePoint, targetPoint, ...props }) {
+  customTrajectory({ sourcePoint, targetPoint, ...props }) {
     const d = getBezierPath([sourcePoint, targetPoint]);
     return h('path', {
       fill: 'transparent',

--- a/packages/core/src/model/GraphModel.ts
+++ b/packages/core/src/model/GraphModel.ts
@@ -91,6 +91,10 @@ class GraphModel {
    */
   nodeMoveRules: NodeMoveRule[] = [];
   /**
+   * 获取自定义连线轨迹
+   */
+  getAnchorLine: Definition['getAnchorLine'];
+  /**
    * 在图上操作创建边时，默认使用的边类型.
    */
   @observable edgeType: string;
@@ -147,6 +151,7 @@ class GraphModel {
       idGenerator,
       edgeGenerator,
       animation,
+      getAnchorLine,
     } = options;
     this.background = background;
     if (typeof grid === 'object') {
@@ -164,6 +169,7 @@ class GraphModel {
     this.partial = options.partial;
     this.overlapMode = options.overlapMode || 0;
     this.idGenerator = idGenerator;
+    this.getAnchorLine = getAnchorLine;
     this.edgeGenerator = createEdgeGenerator(this, edgeGenerator);
     this.width = options.width || this.rootEl.getBoundingClientRect().width;
     this.height = options.height || this.rootEl.getBoundingClientRect().height;

--- a/packages/core/src/model/GraphModel.ts
+++ b/packages/core/src/model/GraphModel.ts
@@ -93,7 +93,7 @@ class GraphModel {
   /**
    * 获取自定义连线轨迹
    */
-  getTrajectory: Definition['getTrajectory'];
+  customTrajectory: Definition['customTrajectory'];
   /**
    * 在图上操作创建边时，默认使用的边类型.
    */
@@ -151,7 +151,7 @@ class GraphModel {
       idGenerator,
       edgeGenerator,
       animation,
-      getTrajectory,
+      customTrajectory,
     } = options;
     this.background = background;
     if (typeof grid === 'object') {
@@ -169,7 +169,7 @@ class GraphModel {
     this.partial = options.partial;
     this.overlapMode = options.overlapMode || 0;
     this.idGenerator = idGenerator;
-    this.getTrajectory = getTrajectory;
+    this.customTrajectory = customTrajectory;
     this.edgeGenerator = createEdgeGenerator(this, edgeGenerator);
     this.width = options.width || this.rootEl.getBoundingClientRect().width;
     this.height = options.height || this.rootEl.getBoundingClientRect().height;

--- a/packages/core/src/model/GraphModel.ts
+++ b/packages/core/src/model/GraphModel.ts
@@ -93,7 +93,7 @@ class GraphModel {
   /**
    * 获取自定义连线轨迹
    */
-  getAnchorLine: Definition['getAnchorLine'];
+  getTrajectory: Definition['getTrajectory'];
   /**
    * 在图上操作创建边时，默认使用的边类型.
    */
@@ -151,7 +151,7 @@ class GraphModel {
       idGenerator,
       edgeGenerator,
       animation,
-      getAnchorLine,
+      getTrajectory,
     } = options;
     this.background = background;
     if (typeof grid === 'object') {
@@ -169,7 +169,7 @@ class GraphModel {
     this.partial = options.partial;
     this.overlapMode = options.overlapMode || 0;
     this.idGenerator = idGenerator;
-    this.getAnchorLine = getAnchorLine;
+    this.getTrajectory = getTrajectory;
     this.edgeGenerator = createEdgeGenerator(this, edgeGenerator);
     this.width = options.width || this.rootEl.getBoundingClientRect().width;
     this.height = options.height || this.rootEl.getBoundingClientRect().height;

--- a/packages/core/src/options.ts
+++ b/packages/core/src/options.ts
@@ -7,6 +7,7 @@ import {
   EdgeData,
   Extension,
   GraphConfigData,
+  Point
 } from './type';
 import { KeyboardDef } from './keyboard';
 import { EditConfigInterface } from './model/EditConfigModel';
@@ -128,8 +129,8 @@ export type Definition = {
 } & EditConfigInterface;
 
 export interface CustomAnchorLineProps {
-  sourcePoint: { x:number, y:number };
-  targetPoint: { x:number, y:number };
+  sourcePoint: Point;
+  targetPoint: Point;
   [key: string]: any;
 }
 

--- a/packages/core/src/options.ts
+++ b/packages/core/src/options.ts
@@ -124,7 +124,7 @@ export type Definition = {
    *        any: 自定义边及其他数据
    */
   edgeGenerator?: (sourceNode: any, targetNode: any, currentEdge?: any) => string | any | undefined;
-  getAnchorLine?: (props: CustomAnchorLineProps) => VNode;
+  customTrajectory?: (props: CustomAnchorLineProps) => VNode;
   [key: string]: any;
 } & EditConfigInterface;
 

--- a/packages/core/src/options.ts
+++ b/packages/core/src/options.ts
@@ -1,4 +1,5 @@
 import { assign } from 'lodash-es';
+import { VNode } from 'preact';
 import { GridOptions } from './view/overlay/Grid';
 import { BackgroundConfig } from './view/overlay/BackgroundOverlay';
 import {
@@ -122,8 +123,15 @@ export type Definition = {
    *        any: 自定义边及其他数据
    */
   edgeGenerator?: (sourceNode: any, targetNode: any, currentEdge?: any) => string | any | undefined;
+  getAnchorLine?: (props: CustomAnchorLineProps) => VNode;
   [key: string]: any;
 } & EditConfigInterface;
+
+export interface CustomAnchorLineProps {
+  sourcePoint: { x:number, y:number };
+  targetPoint: { x:number, y:number };
+  [key: string]: any;
+}
 
 export interface GuardsTypes {
   beforeClone?: (data: NodeData | GraphConfigData) => boolean;

--- a/packages/core/src/view/Anchor.tsx
+++ b/packages/core/src/view/Anchor.tsx
@@ -195,6 +195,11 @@ class Anchor extends Component<IProps, IState> {
     });
   };
 
+  get getAnchorLine() {
+    const { graphModel: { getAnchorLine } } = this.props;
+    return getAnchorLine;
+  }
+
   checkEnd = (event) => {
     const {
       graphModel, nodeModel, anchorData: { x, y, id },
@@ -335,18 +340,28 @@ class Anchor extends Component<IProps, IState> {
             }
           }}
         >
-          { this.getAnchorShape() }
+          {this.getAnchorShape()}
         </g>
-        {this.isShowLine() && (
-          <Line
-            x1={startX}
-            y1={startY}
-            x2={endX}
-            y2={endY}
-            {...edgeStyle}
-            pointer-events="none"
-          />
-        )}
+        {this.isShowLine()
+        && (this.getAnchorLine
+          ? this.getAnchorLine(
+            { sourcePoint: { x: startX, y: startY },
+              targetPoint: {
+                x: endX, y: endY,
+              },
+              ...edgeStyle,
+            },
+          )
+          : (
+            <Line
+              x1={startX}
+              y1={startY}
+              x2={endX}
+              y2={endY}
+              {...edgeStyle}
+              pointer-events="none"
+            />
+          ))}
       </g>
     );
   }

--- a/packages/core/src/view/Anchor.tsx
+++ b/packages/core/src/view/Anchor.tsx
@@ -195,9 +195,9 @@ class Anchor extends Component<IProps, IState> {
     });
   };
 
-  get getAnchorLine() {
-    const { graphModel: { getAnchorLine } } = this.props;
-    return getAnchorLine;
+  get customTrajectory() {
+    const { graphModel: { customTrajectory } } = this.props;
+    return customTrajectory;
   }
 
   checkEnd = (event) => {
@@ -343,8 +343,8 @@ class Anchor extends Component<IProps, IState> {
           {this.getAnchorShape()}
         </g>
         {this.isShowLine()
-        && (this.getAnchorLine
-          ? this.getAnchorLine(
+        && (this.customTrajectory
+          ? this.customTrajectory(
             { sourcePoint: { x: startX, y: startY },
               targetPoint: {
                 x: endX, y: endY,


### PR DESCRIPTION
由于当前从锚点拖出的连线只支持直线，效果不佳，能否在`LogicFlow`配置项中加一个`getAnchorLine`参数供用户自定义，通过用户自己调用`h`函数来自定义路径