### PR TITLE
fix: add edge copying when copying a group(#1346)

### DIFF
--- a/packages/core/src/LogicFlow.tsx
+++ b/packages/core/src/LogicFlow.tsx
@@ -693,7 +693,7 @@ export default class LogicFlow {
   /**
    * 添加多个元素, 包括边和节点。
    */
-  addElements({ nodes, edges }: GraphConfigData): GraphConfigModel {
+  addElements({ nodes, edges }: GraphConfigData, distance = 40): GraphConfigModel {
     const nodeIdMap = {};
     const elements = {
       nodes: [],

--- a/packages/core/src/constant/constant.ts
+++ b/packages/core/src/constant/constant.ts
@@ -40,6 +40,7 @@ export enum EventType {
   NODE_DBCLICK = 'node:dbclick',
   NODE_DELETE = 'node:delete',
   NODE_ADD = 'node:add',
+  NODE_GROUP_COPY = 'node:group-copy-add',
   NODE_DND_ADD = 'node:dnd-add',
   NODE_DND_DRAG = 'node:dnd-drag',
   NODE_MOUSEDOWN = 'node:mousedown',

--- a/packages/core/src/keyboard/shortcut.ts
+++ b/packages/core/src/keyboard/shortcut.ts
@@ -36,6 +36,7 @@ function translationEdgeData(edgeData, distance) {
 }
 
 const TRANSLATION_DISTANCE = 40;
+let CHILDREN_TRANSLATION_DISTANCE = 40;
 
 export function initDefaultShortcut(lf: LogicFlow, graph: GraphModel) {
   const { keyboard } = lf;
@@ -43,6 +44,7 @@ export function initDefaultShortcut(lf: LogicFlow, graph: GraphModel) {
 
   // 复制
   keyboard.on(['cmd + c', 'ctrl + c'], () => {
+    CHILDREN_TRANSLATION_DISTANCE = TRANSLATION_DISTANCE;
     if (!keyboardOptions.enabled) return true;
     if (graph.textEditElement) return true;
     const { guards } = lf.options;
@@ -63,12 +65,13 @@ export function initDefaultShortcut(lf: LogicFlow, graph: GraphModel) {
     if (graph.textEditElement) return true;
     if (selected && (selected.nodes || selected.edges)) {
       lf.clearSelectElements();
-      const addElements = lf.addElements(selected);
+      const addElements = lf.addElements(selected, CHILDREN_TRANSLATION_DISTANCE);
       if (!addElements) return true;
       addElements.nodes.forEach(node => lf.selectElementById(node.id, true));
       addElements.edges.forEach(edge => lf.selectElementById(edge.id, true));
       selected.nodes.forEach(node => translationNodeData(node, TRANSLATION_DISTANCE));
       selected.edges.forEach(edge => translationEdgeData(edge, TRANSLATION_DISTANCE));
+      CHILDREN_TRANSLATION_DISTANCE = CHILDREN_TRANSLATION_DISTANCE + TRANSLATION_DISTANCE;
     }
     return false;
   });


### PR DESCRIPTION
fix: [https://github.com/didi/LogicFlow/issues/1346](https://github.com/didi/LogicFlow/issues/1346)

## 问题发生的原因
### 1. 复制的时候 连接线没有进行复制
目前`packages/extension/src/materials/group/index.ts`的逻辑是在原有的`LogicFlow.addElements()`基础上进行扩充，但是选择`Group`时，拿到的数据是:
```json
{
    "nodes": [
        {
            "id": "node_group",
            "type": "my-group",
            "x": 400,
            "y": 400,
            "children": ["node_item1", "node_item2"]
        }
    ],
    "edges": []
}
```
因此在目前的代码（下面的代码）中，拿到的`children`只有`nodes`数据，或者这么说，目前并没有把`edges`数据放入到`xx.children`中，因此单纯遍历`xx.children`只能复制`nodes`数据
```js
for (let i = 0; i < nodes.length; i++) {
  const node = nodes[i];
  const preId = node.id;
  const { children, ...rest } = node;
  const nodeModel = lf.addNode(rest);
  const fn = (children: Set<string>, current: BaseNodeModel) => {
    children?.forEach((childId: string) => {
      const childNodeModel = lf.getNodeModelById(childId);
      const { x, y, properties, type, text, rotate, children } = childNodeModel;
      const newChildModel = lf.addNode({
        x: x + 40,
        y: y + 40,
        properties,
        type,
        text: {
          ...text,
          x: text.x + 40,
          y: text.y + 40,
        },
        rotate,
      });
      current.addChild(newChildModel.id);
      if (children instanceof Set) {
        fn(children, newChildModel);
      }
    });
  };
  fn(children, nodeModel);
  if (!nodeModel) return { nodes: [], edges: [] };
  if (preId) nodeIdMap[preId] = nodeModel.id;
  elements.nodes.push(nodeModel);
}
```

### 2. 连续的ctrl + v 出现了子节点位置错乱及与父分组所属关系错乱
经过调试发现，当进行`LogicFLow.addNode()`方法调用时，eventType不传默认为EventType.NODE_ADD，因此会触发`appendNodeToGroup()`将新创建的`node`错误地加入到旧的`Group`中
```js
const newChildModel = lf.addNode({
  x: x + 40,
  y: y + 40,
  properties,
  type,
  text: {
    ...text,
    x: text.x + 40,
    y: text.y + 40,
  },
  rotate,
});
// eventType不传默认为EventType.NODE_ADD
addNode(nodeConfig, eventType = EventType.NODE_ADD, e?) {
    return this.graphModel.addNode(nodeConfig, eventType, e);
}

lf.on("node:add,node:drop,node:dnd-add", this.appendNodeToGroup);
```
## 解决方法
1. 遍历`xx.children`的时候拿到`node`对应的所有`edges`（参考`foldGroup()`的逻辑），然后进行创建`edge`

```js
// 存储children内部节点相关的输入边
childNodeModel.incoming.edges.forEach((edge) => {
  edgesNodeModelArray.push(edge);
});
// 存储children内部节点相关的输出边
childNodeModel.outgoing.edges.forEach((edge) => {
  edgesNodeModelArray.push(edge);
});
```

2. `lf.addNode`创建`node`时传入一个新的type，阻止`appendToGroup()`调用

```js
const eventType = EventType.NODE_GROUP_COPY || ('node:group-copy-add' as EventType);
const newChildModel = lf.addNode(
  {
    x: x + distance,
    y: y + distance,
    properties,
    type,
    text: {
      ...text,
      x: text.x + distance,
      y: text.y + distance,
    },
    rotate,
    // 如果不传递type，会自动触发NODE_ADD
    // 有概率触发appendToGroup
  },
  eventType,
);
```

## 目前还发现但是还没解决的问题
1. edge优先级：edge优先级总是比node低，因此新复制的还是旧的edge，拖动时会被node遮盖
2. 选中问题：目前还是维持原来的逻辑，只选中最外层的node（group类型），会造成选中的GroupB的内容元素被GroupA的元素所覆盖，因此只选中最外层的node，group内部元素没有被选中，优先级并没有提升