### PR TITLE
fix(extension): the outermost edges translate 0 when copy a group(#1379)

### DIFF
--- a/packages/extension/src/materials/group/index.ts
+++ b/packages/extension/src/materials/group/index.ts
@@ -106,11 +106,12 @@ class Group {
       // groupInnerChildren.edges.forEach(edge => this.translationEdgeData(edge, distance));
 
       // 最外层的edges继续执行创建edgeModel的流程
+      // 由于最外层会调用translationEdgeData()，因此这里不用传入distance进行偏移
       selectedEdges.forEach((edge) => {
         const edgeModel = this.createEdgeModel(
           edge,
           nodeIdMap,
-          distance,
+          0,
         );
         elements.edges.push(edgeModel);
       });


### PR DESCRIPTION
[https://github.com/didi/LogicFlow/issues/1379](https://github.com/didi/LogicFlow/issues/1379)

## 问题出现的原因

之前写的时候，原先规划是group内部节点模仿外部nodes和edges进行整体偏移，大体逻辑为
```js
// 构建的时候直接偏移，这里不需要再进行再度偏移
// groupInnerChildren.nodes.forEach(node => this.translationNodeData(node, distance));
// groupInnerChildren.edges.forEach(edge => this.translationEdgeData(edge, distance));
```

后面改成在外部进行偏移，然后传入具体的偏移值，这样直接创建的时候就可以进行偏移，不用创建完成后，又再度偏移一次

但是忘记了将最外层`edges`的偏移量去除，因为在原来的`shortcut.ts`中就已经偏移
```js
keyboard.on(['cmd + v', 'ctrl + v'], () => {
    if (!keyboardOptions.enabled) return true;
    if (graph.textEditElement) return true;
    if (selected && (selected.nodes || selected.edges)) {
      lf.clearSelectElements();
      const addElements = lf.addElements(selected, CHILDREN_TRANSLATION_DISTANCE);
      if (!addElements) return true;
      addElements.nodes.forEach(node => lf.selectElementById(node.id, true));
      addElements.edges.forEach(edge => lf.selectElementById(edge.id, true));
      selected.nodes.forEach(node => translationNodeData(node, TRANSLATION_DISTANCE));
      selected.edges.forEach(edge => translationEdgeData(edge, TRANSLATION_DISTANCE));
      CHILDREN_TRANSLATION_DISTANCE = CHILDREN_TRANSLATION_DISTANCE + TRANSLATION_DISTANCE;
    }
    return false;
});
```

##  解决方法

不传入distance创建即可
```js
// 最外层的edges继续执行创建edgeModel的流程
// 由于最外层会调用translationEdgeData()，因此这里不用传入distance进行偏移
selectedEdges.forEach((edge) => {
const edgeModel = this.createEdgeModel(
    edge,
    nodeIdMap,
    0,
);
elements.edges.push(edgeModel);
});
```