### PR TITLE
fix(core): refresh the value of model when mouse down(#1370)

### DIFF
--- a/packages/core/src/util/drag.ts
+++ b/packages/core/src/util/drag.ts
@@ -110,6 +110,9 @@ class StepDrag {
   setStep(step: number) {
     this.step = step;
   }
+  setModel(model: IBaseModel) {
+    this.model = model;
+  }
   handleMouseDown = (e: MouseEvent) => {
     if (e.button !== LEFT_MOUSE_BUTTON_CODE) return;
     if (this.isStopPropagation) e.stopPropagation();

--- a/packages/core/src/util/mobx.ts
+++ b/packages/core/src/util/mobx.ts
@@ -1,4 +1,4 @@
-import { action, observable, computed, toJS, isObservable, configure } from 'mobx';
+import { action, observable, computed, toJS, isObservable, configure, reaction, IReactionDisposer } from 'mobx';
 
 configure({ isolateGlobalState: true });
 
@@ -9,4 +9,6 @@ export {
   isObservable,
   toJS,
   configure,
+  reaction,
+  IReactionDisposer,
 };

--- a/packages/core/src/view/node/BaseNode.tsx
+++ b/packages/core/src/view/node/BaseNode.tsx
@@ -324,6 +324,13 @@ export default abstract class BaseNode extends Component<IProps, IState> {
     this.startTime = new Date().getTime();
     const { editConfigModel } = graphModel;
     if (editConfigModel.adjustNodePosition && model.draggable) {
+      // https://github.com/didi/LogicFlow/issues/1370
+      // 当使用撤销功能：LogicFlow.undo()时，会重新初始化所有model数据，即LogicFlow.undo()时会新构建一个model对象
+      // 但是this.stepDrag并不会重新创建
+      // 导致this.stepDrag持有的model并没有重新赋值，因为之前的做法是构造函数中传入一个model对象
+      // 在StepDrag.ts中只有handleMouseDown、handleMouseMove、handleMouseUp使用到this.model
+      // 因此在handleMouseDown()进行setModel重新将this.props.model的值设置进去，刷新this.model.getData()
+      this.stepDrag && this.stepDrag.setModel(model);
       this.stepDrag && this.stepDrag.handleMouseDown(ev);
     }
   };

--- a/packages/core/src/view/node/BaseNode.tsx
+++ b/packages/core/src/view/node/BaseNode.tsx
@@ -14,6 +14,7 @@ import { cancelRaf, createRaf } from '../../util/raf';
 import { EventArgs } from '../../type';
 import RotateControlPoint from '../Rotate';
 import { TranslateMatrix, RotateMatrix } from '../../util';
+import { reaction, IReactionDisposer } from '../../util/mobx';
 
 type IProps = {
   model: BaseNodeModel;
@@ -36,6 +37,7 @@ export default abstract class BaseNode extends Component<IProps, IState> {
   contextMenuTime: number;
   startTime: number;
   clickTimer: number;
+  modelDisposer: IReactionDisposer;
   constructor(props) {
     super();
     const {
@@ -52,6 +54,21 @@ export default abstract class BaseNode extends Component<IProps, IState> {
       eventCenter,
       model,
     });
+    // https://github.com/didi/LogicFlow/issues/1370
+    // 当使用撤销功能：LogicFlow.undo()时，会重新初始化所有model数据，即LogicFlow.undo()时会新构建一个model对象
+    // 但是this.stepDrag并不会重新创建
+    // 导致this.stepDrag持有的model并没有重新赋值，因为之前的做法是构造函数中传入一个model对象
+    // 使用mobx的reaction监听能力，如果this.props.model发生变化，则进行this.stepDrag.setModel()操作
+    this.modelDisposer = reaction(() => this.props, (newProps) => {
+      if (newProps && newProps.model) {
+        this.stepDrag.setModel(newProps.model);
+      }
+    });
+  }
+  componentWillUnmount() {
+    if (this.modelDisposer) {
+      this.modelDisposer();
+    }
   }
   abstract getShape();
   getAnchorShape(anchorData): h.JSX.Element {
@@ -324,13 +341,6 @@ export default abstract class BaseNode extends Component<IProps, IState> {
     this.startTime = new Date().getTime();
     const { editConfigModel } = graphModel;
     if (editConfigModel.adjustNodePosition && model.draggable) {
-      // https://github.com/didi/LogicFlow/issues/1370
-      // 当使用撤销功能：LogicFlow.undo()时，会重新初始化所有model数据，即LogicFlow.undo()时会新构建一个model对象
-      // 但是this.stepDrag并不会重新创建
-      // 导致this.stepDrag持有的model并没有重新赋值，因为之前的做法是构造函数中传入一个model对象
-      // 在StepDrag.ts中只有handleMouseDown、handleMouseMove、handleMouseUp使用到this.model
-      // 因此在handleMouseDown()进行setModel重新将this.props.model的值设置进去，刷新this.model.getData()
-      this.stepDrag && this.stepDrag.setModel(model);
       this.stepDrag && this.stepDrag.handleMouseDown(ev);
     }
   };


### PR DESCRIPTION
close [https://github.com/didi/LogicFlow/issues/1370](https://github.com/didi/LogicFlow/issues/1370)

## 问题发生的原因

当使用撤销功能：`LogicFlow.undo()`时，会重新初始化所有`nodes`数据，触发`node`对应的`model`数据的重新构建，即`LogicFlow.undo()`时会新构建一个model对象
```ts
// packages/core/src/LogicFlow.tsx
undo() {
  if (!this.history.undoAble()) return;
  // formatData兼容vue数据
  const graphData = formatData(this.history.undo());
  this.clearSelectElements();
  this.graphModel.graphDataToModel(graphData);
}
// packages/core/src/model/GraphModel.ts
graphDataToModel(graphData: GraphConfigData) {
  //...
  if (graphData.nodes) {
    this.nodes = map(graphData.nodes, (node) => {
      const Model = this.getModel(node.type);
      //...
      return new Model(node, this);
    });
  } else {
    this.nodes = [];
  }
  //...
}
```
从而触发`packages/core/src/view/Graph.tsx`的`render()`重新执行
```js
map(graphModel.sortElements, (nodeModel) => (
  this.getComponent(nodeModel, graphModel)
))
```
```js
getComponent(model: BaseEdgeModel | BaseNodeModel, graphModel: GraphModel, overlay = 'canvas-overlay') {
    const { getView } = this.props;
    const View = getView(model.type);
    return (
      <View
        key={model.id}
        model={model}
        graphModel={graphModel}
        overlay={overlay}
      />
    );
}
```
从上面代码可以知道，传入的`props.model`已经更新，但是`BaseNode`并不会重新构建，`this.stepDrag`也不会重新创建，导致`this.stepDrag`持有的`model`并没有重新赋值，因为是构造函数中传入一个`model`对象
```js
export default abstract class BaseNode extends Component<IProps, IState> {
    //...
    constructor(props) {
      super();
      const {
        graphModel: { gridSize, eventCenter }, model,
      } = props;
      // 不在构造函数中判断，因为editConfig可能会被动态改变
      this.stepDrag = new StepDrag({
        onDragStart: this.onDragStart,
        onDragging: this.onDragging,
        onDragEnd: this.onDragEnd,
        step: gridSize,
        eventType: 'NODE',
        isStopPropagation: false,
        eventCenter,
        model,
      });
    }
    //...
}
```

而节点移动、拖拽节点所`emit`的数据恰恰好就是`this.model.getData()`（如下面代码所示），因此导致了`使用撤销（lf.undo）,节点移动、拖拽节点放开data里面x,y的值没有变化`，因此它持有的是一个废弃的`this.model`
```js
class StepDrag {
  handleMouseDown = (e: MouseEvent) => {
    //...
    const elementData = this.model?.getData();
    this.eventCenter?.emit(EventType[`${this.eventType}_MOUSEDOWN`], {
      e,
      data: this.data || elementData,
    });
    //...
  };
  handleMouseMove = (e: MouseEvent) => {
    //...
    const elementData = this.model?.getData();
    if (!this.isDragging) {
      this.eventCenter?.emit(EventType[`${this.eventType}_DRAGSTART`], {
        e,
        data: this.data || elementData,
      });
      this.onDragStart({ event: e });
    }
    //...
  };
  handleMouseUp = (e: MouseEvent) => {
    //...
    const elementData = this.model?.getData();
    this.eventCenter?.emit(EventType[`${this.eventType}_MOUSEUP`], {
      e,
      data: this.data || elementData,
    });
    //...
  };
}
```

## 解决方法

由于在`StepDrag.ts`中只有`handleMouseDown`、`handleMouseMove`、`handleMouseUp`使用到`this.model`，因此在`handleMouseDown()`进行`setModel`重新将`this.props.model`的值设置进去，刷新`this.model`

```js
handleMouseDown = (ev: MouseEvent) => {
  const { model, graphModel } = this.props;
  this.startTime = new Date().getTime();
  const { editConfigModel } = graphModel;
  if (editConfigModel.adjustNodePosition && model.draggable) {
    // https://github.com/didi/LogicFlow/issues/1370
    // 当使用撤销功能：LogicFlow.undo()时，会重新初始化所有model数据，即LogicFlow.undo()时会新构建一个model对象
    // 但是this.stepDrag并不会重新创建
    // 导致this.stepDrag持有的model并没有重新赋值，因为之前的做法是构造函数中传入一个model对象
    // 在StepDrag.ts中只有handleMouseDown、handleMouseMove、handleMouseUp使用到this.model
    // 因此在handleMouseDown()进行setModel重新将this.props.model的值设置进去，刷新this.model.getData()
    this.stepDrag && this.stepDrag.setModel(model);
    this.stepDrag && this.stepDrag.handleMouseDown(ev);
  }
};
```

