### PR TITLE
Fix:复现泳道时标题位置偏移

### DIFF
--- a/packages/extension/src/bpmn-elements/presets/Pool/Pool.ts
+++ b/packages/extension/src/bpmn-elements/presets/Pool/Pool.ts
@@ -25,6 +25,10 @@ class HorizontalLaneModel extends GroupNode.model {
     this.zIndex = 1;
     this.text.editable = true;
     this.toJSON = poolToJSON;
+    // Fix:因为宽高保存在properties中，复现泳道时获取到的是基础宽高而不是properties的宽高，所以异步修改左侧标题的x轴坐标。
+    setTimeout(() => {
+      this.text.x = this.x - this.width / 2 + 11;
+    }, 0);
   }
 
   setAttributes() {


### PR DESCRIPTION
**如何复现此bug？**
向画布中绘制一个泳道节点，改变其大小。将其保存成任意数据格式，用此数据渲染到画布时，标题位置偏移。
修复后
![image](https://github.com/didi/LogicFlow/assets/86914617/17228ee1-d721-4299-b735-f3df5c78a479)
修复前
![image](https://github.com/didi/LogicFlow/assets/86914617/a2cdac12-2d62-4e55-91ec-a4e097d4932c)
