### PR TITLE
fix: prevent node without anchors using InsertNodeInPolyline(#1077)

### DIFF
--- a/packages/core/src/model/edge/BaseEdgeModel.ts
+++ b/packages/core/src/model/edge/BaseEdgeModel.ts
@@ -240,8 +240,10 @@ class BaseEdgeModel implements IBaseModel {
   /**
    * 内部方法，计算两个节点相连是起点位置
    */
-  getBeginAnchor(sourceNode, targetNode): Point {
-    let position;
+  getBeginAnchor(sourceNode, targetNode): Point | undefined {
+    // https://github.com/didi/LogicFlow/issues/1077
+    // 可能拿到的sourceAnchors为空数组，因此position可能返回为undefined
+    let position: Point | undefined;
     let minDistance;
     const sourceAnchors = getAnchors(sourceNode);
     sourceAnchors.forEach((anchor) => {
@@ -260,8 +262,10 @@ class BaseEdgeModel implements IBaseModel {
   /**
    * 内部方法，计算两个节点相连是终点位置
    */
-  getEndAnchor(targetNode): Point {
-    let position;
+  getEndAnchor(targetNode): Point | undefined {
+    // https://github.com/didi/LogicFlow/issues/1077
+    // 可能拿到的targetAnchors为空数组，因此position可能返回为undefined
+    let position: Point | undefined;
     let minDistance;
     const targetAnchors = getAnchors(targetNode);
     targetAnchors.forEach((anchor) => {
@@ -474,6 +478,14 @@ class BaseEdgeModel implements IBaseModel {
   setAnchors(): void {
     if (!this.sourceAnchorId || !this.startPoint) {
       const anchor = this.getBeginAnchor(this.sourceNode, this.targetNode);
+      if (!anchor && (!this.startPoint || !this.sourceAnchorId)) {
+        // https://github.com/didi/LogicFlow/issues/1077
+        // 当用户自定义getDefaultAnchor(){return []}时，表示：不显示锚点，也不允许其他节点连接到此节点
+        // 此时拿到的anchor=undefined，下面会直接报错
+        throw new Error(
+          '无法获取beginAnchor，请检查anchors相关逻辑，anchors不能为空',
+        );
+      }
       if (!this.startPoint) {
         this.startPoint = {
           x: anchor.x,
@@ -486,6 +498,14 @@ class BaseEdgeModel implements IBaseModel {
     }
     if (!this.targetAnchorId || !this.endPoint) {
       const anchor = this.getEndAnchor(this.targetNode);
+      if (!anchor && (!this.endPoint || !this.targetAnchorId)) {
+        // https://github.com/didi/LogicFlow/issues/1077
+        // 当用户自定义getDefaultAnchor(){return []}时，表示：不显示锚点，也不允许其他节点连接到此节点
+        // 此时拿到的anchor=undefined，下面会直接报错
+        throw new Error(
+          '无法获取endAnchor，请检查anchors相关逻辑，anchors不能为空',
+        );
+      }
       if (!this.endPoint) {
         this.endPoint = {
           x: anchor.x,

--- a/packages/extension/examples/insert-node-in-polyline/NotAllowConnectRect.mjs
+++ b/packages/extension/examples/insert-node-in-polyline/NotAllowConnectRect.mjs
@@ -1,0 +1,15 @@
+
+class NotAllowConnectRectModel extends RectNodeModel {
+  getDefaultAnchor () {
+    return [];
+  }
+}
+class NotAllowConnectRectView extends RectNode {
+
+}
+
+export default {
+  type: "not-allow-connect",
+  view: NotAllowConnectRectView,
+  model: NotAllowConnectRectModel
+};

--- a/packages/extension/examples/insert-node-in-polyline/index.html
+++ b/packages/extension/examples/insert-node-in-polyline/index.html
@@ -38,7 +38,7 @@
   </style>
 </head>
 <body>
-  <div id="rect"></div>
+  <div id="rect">不允许连接的rect</div>
   <div id="circle"></div>
   <div id="app"></div>
   <div id="debug"></div>
@@ -48,6 +48,6 @@
   <script>
     LogicFlow.use(InsertNodeInPolyline);
   </script>
-  <script src="./index.js"></script>
+  <script type="module" src="./index.js"></script>
 </body>
 </html>

--- a/packages/extension/examples/insert-node-in-polyline/index.js
+++ b/packages/extension/examples/insert-node-in-polyline/index.js
@@ -1,3 +1,5 @@
+import NotAllowConnectRect from './NotAllowConnectRect.mjs';
+
 window.onload = function () {
   const lf = new LogicFlow({
     container: document.querySelector('#app'),
@@ -6,11 +8,15 @@ window.onload = function () {
       size: 20,
     },
   });
+  lf.register(NotAllowConnectRect);
+  lf.on('connection:not-allowed', ({ data, msg }) => {
+    console.error('connection:not-allowed的原因是', msg);
+  });
   lf.render();
   // 初始化拖入功能
   document.querySelector('#rect').addEventListener('mousedown', () => {
     lf.dnd.startDrag({
-      type: 'rect',
+      type: 'not-allow-connect',
     });
   });
   document.querySelector('#circle').addEventListener('mousedown', () => {


### PR DESCRIPTION
close [https://github.com/didi/LogicFlow/issues/1077](https://github.com/didi/LogicFlow/issues/1077)

## 问题发生的原因

参照[https://github.com/didi/LogicFlow/issues/454](https://github.com/didi/LogicFlow/issues/454)，当用户自定义`getDefaultAnchor(){return []}`时，表示：不显示锚点，也不允许其他节点连接到此节点
```js
class NotAllowConnectRectModel extends RectNodeModel {
  getDefaultAnchor () {
    return [];
  }
}
```

而`insert-node-in-polyline`没有对这方面进行处理，当用户使用自定义的节点（不显示锚点，也不允许其他节点连接到此节点），然后插入到两个节点之间的`edge`时，会触发`insetNode()`方法，从而触发
```js
// packages/extension/src/insert-node-in-polyline/index.ts
for (let i = 0; i < edges.length; i++) {
    // eslint-disable-next-line max-len
    const { crossIndex, crossPoints } = isNodeInSegment(
      nodeModel,
      edges[i],
      this.deviation,
    );

    if (crossIndex >= 0) {
        //...
        this._lf.deleteEdge(id);
        this._lf.addEdge({
            type,
            sourceNodeId,
            targetNodeId: nodeData.id,
            startPoint,
            endPoint,
            pointsList: [
              ...pointsList.slice(0, crossIndex),
              crossPoints.startCrossPoint,
            ],
        });
    }
}
```
即找到两个节点之间的`edge`，然后
- 删除两个节点之间的`edge`
- 两个节点和当前插入节点之间的边的创建

边的创建过程中会触发
```js
// packages/core/src/model/edge/BaseEdgeModel.ts
function setAnchors(){
    if (!this.sourceAnchorId || !this.startPoint) {
        const anchor = this.getBeginAnchor(this.sourceNode, this.targetNode);
        if (!this.startPoint) {
            this.startPoint = {
              x: anchor.x,
              y: anchor.y,
            };
        }
        if (!this.sourceAnchorId) {
            this.sourceAnchorId = anchor.id;
        }
    }
}
getBeginAnchor(sourceNode, targetNode) {
    let position;
    let minDistance;
    const sourceAnchors = getAnchors(sourceNode);
    sourceAnchors.forEach((anchor) => {
      const distance = twoPointDistance(anchor, targetNode);
      if (minDistance === undefined) {
        minDistance = distance;
        position = anchor;
      } else if (distance < minDistance) {
        minDistance = distance;
        position = anchor;
      }
    });
    return position;
}
```

而由于自定义节点是`getDefaultAnchor(){return []}`，因此`getAnchors(sourceNode)`拿到的是一个空的数组，从而导致`position`没有赋值，返回一个`undefined`，`anchor.x`实际为`undefined.x`，从而导致报错

## 解决方法
在`insetNode()`的逻辑执行之前，直接进行`anchors`的判断，如果为空，就不执行下面的`edge`断边然后创建的逻辑，并且仿造`insetNode()`中最终的校验逻辑，返回一个`EventType.CONNECTION_NOT_ALLOWED`的错误说明

```js
// fix: https://github.com/didi/LogicFlow/issues/1077
// 参照https://github.com/didi/LogicFlow/issues/454=>当getDefaultAnchor(){return []}表示：不显示锚点，也不允许其他节点连接到此节点
// 当getDefaultAnchor=[]，直接阻止下面进行edges的截断插入node相关逻辑
const anchorArray = nodeModel.getDefaultAnchor();
const isNotAllowConnect = !anchorArray || anchorArray.length === 0;
if (isNotAllowConnect) {
  this._lf.graphModel.eventCenter.emit(EventType.CONNECTION_NOT_ALLOWED, {
    data: nodeData,
    msg: "自定义类型节点不显示锚点，也不允许其他节点连接到此节点",
  });
  return;
}

```

## 额外增加的提示代码
由于`getBeginAnchor()`方法中可能拿到一个空的`anchors`，从而返回一个`anchor=undefined`，因此增加了一个校验逻辑，当拿到空的`anchors`，返回一个`anchor=undefined`，又需要用到`anchor.x`的时候，提示一个错误
```js
if (!anchor && (!this.startPoint || !this.sourceAnchorId)) {
  // https://github.com/didi/LogicFlow/issues/1077
  // 当用户自定义getDefaultAnchor(){return []}时，表示：不显示锚点，也不允许其他节点连接到此节点
  // 此时拿到的anchor=undefined，下面会直接报错
  throw new Error(
    "无法获取beginAnchor，请检查anchors相关逻辑，anchors不能为空"
  );
}
```
