### PR TITLE
 修复：缩放快捷键 CTRL + 滚轮会触发浏览器事件（使用选区当框选后）

### DIFF
--- a/packages/core/src/style/index.css
+++ b/packages/core/src/style/index.css
@@ -189,6 +189,7 @@
   border: 2px dashed rgba(24, 125, 255, 0.8);
   box-shadow: 0px 0px 3px 0px rgba(24, 125, 255, 0.5);
   cursor: move;
+  pointer-events: none;
 }
 .lf-edge-adjust-point {
   cursor: move;


### PR DESCRIPTION
Fixes #1423