### PR TITLE
fix:修复在qiankun等微前端框架中在子应用里使用时下载方法报错的问题

### DIFF
--- a/packages/extension/src/tools/snapshot/index.ts
+++ b/packages/extension/src/tools/snapshot/index.ts
@@ -34,7 +34,7 @@ class Snapshot {
   }
   triggerDownload(imgURI: string) {
     const evt = new MouseEvent('click', {
-      view: window,
+      view: document.defaultView,
       bubbles: false,
       cancelable: true,
     });


### PR DESCRIPTION
同 https://github.com/apache/echarts/pull/12643

在qiankun、wujie等微前端框架中，子应用获取到的window是一个proxy对象

当LogicFlow在子应用中加载时，会导致触发下载的方法中新建点击事件失败，进而导致下载图片报错

因此将view字段的值从直接取window改为取document.defaultView