### PR TITLE
fix:修复笔记本触摸板点击节点事件失效

### DIFF
--- a/packages/core/src/view/node/BaseNode.tsx
+++ b/packages/core/src/view/node/BaseNode.tsx
@@ -35,6 +35,7 @@ export default abstract class BaseNode extends Component<IProps, IState> {
   }
   stepDrag: StepDrag;
   contextMenuTime: number;
+  mouseUpDrag: boolean;
   startTime: number;
   clickTimer: number;
   modelDisposer: IReactionDisposer;
@@ -261,13 +262,17 @@ export default abstract class BaseNode extends Component<IProps, IState> {
     const { model } = this.props;
     model.isDragging = false;
   };
+  handleMouseUp = () => {
+    const { model } = this.props;
+    this.mouseUpDrag = model.isDragging;
+  };
   handleClick = (e: MouseEvent) => {
     // 节点拖拽进画布之后，不触发click事件相关emit
     // 点拖拽进画布没有触发mousedown事件，没有startTime，用这个值做区分
+    const isDragging = this.mouseUpDrag === false;
     if (!this.startTime) return;
-    const time = new Date().getTime() - this.startTime;
-    if (time > 200) return; // 事件大于200ms，认为是拖拽, 不触发click事件。
     const { model, graphModel } = this.props;
+    if (!isDragging) return; // 如果是拖拽, 不触发click事件。
     // 节点数据，多为事件对象数据抛出
     const nodeData = model.getData();
     const position = graphModel.getPointByClient({
@@ -426,6 +431,7 @@ export default abstract class BaseNode extends Component<IProps, IState> {
         <g
           className={`${this.getStateClassName()} ${className}`}
           onMouseDown={this.handleMouseDown}
+          onMouseUp={this.handleMouseUp}
           onClick={this.handleClick}
           onMouseEnter={this.setHoverON}
           onMouseOver={this.setHoverON}


### PR DESCRIPTION
修复[issue#1071](https://github.com/didi/LogicFlow/issues/1071)：笔记本触摸板点击节点时并没有触发node:click事件。
原代码判断逻辑为：mousedown和click间隔时间大于200ms，则认为是拖拽，不触发click事件。
这样判断并不是最优方式， 原因：
1.当使用触摸板点击时，时间间隔大于200ms，具体是210ms-240ms之间，导致没有触发node:click事件。
2.当单次拖拽操作很短的情况下（在200ms内），按照原代码，会触发node:click事件，这与期望不符。
本次提交的改动：对节点增加mouseup监听，对拖拽状态isDragging状态进行记录，在handleClick中进行判断，确保在鼠标及触摸板点击时都能正常触发node:click事件。