### PR TITLE
fix: updateEditConfig修改stopMoveGraph属性无效

### DIFF
--- a/packages/core/src/LogicFlow.tsx
+++ b/packages/core/src/LogicFlow.tsx
@@ -789,6 +789,7 @@ export default class LogicFlow {
    */
   updateEditConfig(config: EditConfigInterface) {
     this.graphModel.editConfigModel.updateEditConfig(config);
+    this.graphModel.transformModel.updateTranslateLimits();
   }
   /**
    * 获取流程图当前编辑相关设置

--- a/packages/core/src/model/GraphModel.ts
+++ b/packages/core/src/model/GraphModel.ts
@@ -160,7 +160,7 @@ class GraphModel {
     this.rootEl = container;
     this.editConfigModel = new EditConfigModel(options);
     this.eventCenter = new EventEmitter();
-    this.transformModel = new TransformModel(this.eventCenter, options);
+    this.transformModel = new TransformModel(this.eventCenter, this.editConfigModel);
     this.theme = updateTheme(options.style);
     this.edgeType = options.edgeType || 'polyline';
     this.width = options.width;

--- a/packages/core/src/model/TransformModel.ts
+++ b/packages/core/src/model/TransformModel.ts
@@ -2,6 +2,7 @@ import { observable, action } from '../util/mobx';
 import { EventType } from '../constant/constant';
 import EventEmitter from '../event/eventEmitter';
 import { PointTuple, ZoomParam } from '../type';
+import { EditConfigInterface } from './EditConfigModel';
 
 export interface TransformInterface {
   SCALE_X: number;
@@ -42,14 +43,15 @@ export default class TransformModel implements TransformInterface {
   @observable TRANSLATE_Y = 0;
   @observable ZOOM_SIZE = 0.04;
   eventCenter: EventEmitter;
+  editConfigModel: EditConfigInterface;
   translateLimitMinX: number;
   translateLimitMinY: number;
   translateLimitMaxX: number;
   translateLimitMaxY: number;
-  constructor(eventCenter, options) {
+  constructor(eventCenter, editConfigModel) {
     this.eventCenter = eventCenter;
-    const { stopMoveGraph = false } = options;
-    this.updateTranslateLimits(stopMoveGraph);
+    this.editConfigModel = editConfigModel;
+    this.updateTranslateLimits();
   }
   setZoomMiniSize(size: number): void {
     this.MINI_SCALE_SIZE = size;
@@ -203,7 +205,8 @@ export default class TransformModel implements TransformInterface {
   /**
    * 更新画布可以移动范围
    */
-  updateTranslateLimits(limit: boolean | 'vertical' | 'horizontal' | [number, number, number, number]) {
+  updateTranslateLimits() {
+    const limit = this.editConfigModel.stopMoveGraph ?? false;
     const boundary = Array.isArray(limit) && limit.length === 4
       ? limit
       : translateLimitsMap[limit.toString()];


### PR DESCRIPTION
fix: #1482 

问题发生的原因
updateTranslateLimits方法只在constructor中调用一次，当stopMoveGraph改变时未再次执行
![image](https://github.com/didi/LogicFlow/assets/8906885/42f56261-e020-4424-8013-d3d68c6b6169)
