### PR TITLE
fix: 修复选区插件无法触发鼠标事件的问题，同时兼容 Ctrl + 滚轮事件

### DIFF
--- a/packages/core/src/style/index.css
+++ b/packages/core/src/style/index.css
@@ -189,7 +189,6 @@
   border: 2px dashed rgba(24, 125, 255, 0.8);
   box-shadow: 0px 0px 3px 0px rgba(24, 125, 255, 0.5);
   cursor: move;
-  pointer-events: none;
 }
 .lf-edge-adjust-point {
   cursor: move;

--- a/packages/extension/src/components/selection-select/index.ts
+++ b/packages/extension/src/components/selection-select/index.ts
@@ -58,6 +58,7 @@ class SelectionSelect {
       this.wrapper = wrapper;
       document.addEventListener('mousemove', this.__draw);
       document.addEventListener('mouseup', this.__drawOff);
+      document.addEventListener('wheel', this.__zoom, { passive: false });
     });
   }
   /**
@@ -141,6 +142,17 @@ class SelectionSelect {
       }
     });
     this.lf.emit('selection:selected', elements);
+  };
+  __zoom = (ev: WheelEvent) => {
+    ev.preventDefault();
+    const newEvent = new WheelEvent('wheel', {
+      deltaX: ev.deltaX,
+      deltaY: ev.deltaY,
+      clientX: ev.clientX,
+      clientY: ev.clientY,
+      ctrlKey: ev.ctrlKey,
+    });
+    this.lf.container?.querySelector('.lf-canvas-overlay[name="canvas-overlay"]')?.dispatchEvent(newEvent);
   };
   open() {
     this.__disabled = false;


### PR DESCRIPTION
本地构建项目失败没能启动项目来测试这个改动是否能真真正正的解决该问题，但在 #1533 提供的[示例](https://github.com/ChangeSuger/logicflow-bug-report)基础上做过测试，具体来说是：

1. 手动选区，创建选区元素，然后通过 DevTool 取消选区元素的该样式

https://github.com/didi/LogicFlow/blob/bc553cb959aed494a6e52f75634a3bda88f1cd29/packages/core/src/style/index.css#L192

2. 在控制台输入以下代码：

```js
document.querySelector('.lf-multiple-select').addEventListener('wheel', (ev) => {
    ev.preventDefault();
    const newEvent = new WheelEvent('wheel', {
        deltaX: ev.deltaX,
        deltaY: ev.deltaY,
        clientX: ev.clientX,
        clientY: ev.clientY,
        ctrlKey: ev.ctrlKey,
    });

    document.querySelector('div#lf-view').querySelector('.lf-canvas-overlay[name="canvas-overlay"]').dispatchEvent(newEvent);
}, { passive: false });
```

PR 中的更改与上述操作相似。