### PR TITLE
fix:修复polyline调整后，被框选拖动而出现回退的问题

### DIFF
--- a/packages/core/src/model/GraphModel.ts
+++ b/packages/core/src/model/GraphModel.ts
@@ -1016,7 +1016,9 @@ class GraphModel {
       const targetMoveDistance = nodeIdMap[edgeModel.targetNodeId];
       let textDistanceX;
       let textDistanceY;
-      if (sourceMoveDistance && targetMoveDistance && edgeModel.type === 'polyline') {
+      if (sourceMoveDistance
+        && targetMoveDistance
+        && edgeModel.modelType === ModelType.POLYLINE_EDGE) {
         // 移动框选区时，如果边polyline在框选范围内，则边的轨迹pointsList也要整体移动
         [textDistanceX, textDistanceY] = sourceMoveDistance;
         edgeModel.updatePointsList(textDistanceX, textDistanceY);

--- a/packages/core/src/model/GraphModel.ts
+++ b/packages/core/src/model/GraphModel.ts
@@ -1013,16 +1013,22 @@ class GraphModel {
       const edgeModel = this.edges[i];
       const { x, y } = edgeModel.textPosition;
       const sourceMoveDistance = nodeIdMap[edgeModel.sourceNodeId];
+      const targetMoveDistance = nodeIdMap[edgeModel.targetNodeId];
       let textDistanceX;
       let textDistanceY;
-      if (sourceMoveDistance) {
+      if (sourceMoveDistance && targetMoveDistance && edgeModel.type === 'polyline') {
+        // 移动框选区时，如果边polyline在框选范围内，则边的轨迹pointsList也要整体移动
         [textDistanceX, textDistanceY] = sourceMoveDistance;
-        edgeModel.moveStartPoint(textDistanceX, textDistanceY);
-      }
-      const targetMoveDistance = nodeIdMap[edgeModel.targetNodeId];
-      if (targetMoveDistance) {
-        [textDistanceX, textDistanceY] = targetMoveDistance;
-        edgeModel.moveEndPoint(textDistanceX, textDistanceY);
+        edgeModel.updatePointsList(textDistanceX, textDistanceY);
+      } else {
+        if (sourceMoveDistance) {
+          [textDistanceX, textDistanceY] = sourceMoveDistance;
+          edgeModel.moveStartPoint(textDistanceX, textDistanceY);
+        }
+        if (targetMoveDistance) {
+          [textDistanceX, textDistanceY] = targetMoveDistance;
+          edgeModel.moveEndPoint(textDistanceX, textDistanceY);
+        }
       }
       if (sourceMoveDistance || targetMoveDistance) {
         // https://github.com/didi/LogicFlow/issues/1191

--- a/packages/core/src/model/edge/PolylineEdgeModel.ts
+++ b/packages/core/src/model/edge/PolylineEdgeModel.ts
@@ -298,6 +298,15 @@ export default class PolylineEdgeModel extends BaseEdgeModel {
   }
 
   @action
+  updatePointsList(deltaX, deltaY): void {
+    this.pointsList.forEach(item => {
+      item.x += deltaX;
+      item.y += deltaY;
+    });
+    this.initPoints();
+  }
+
+  @action
   dragAppendStart() {
     // mobx observer 对象被iterator处理会有问题
     this.draggingPointList = this.pointsList.map(i => i);


### PR DESCRIPTION
修复[issue#1541](https://github.com/didi/LogicFlow/issues/1541)
之前开发也发现了这个问题，当边为polyline(或polyline继承边)时就会出现这种情况。原因是框选拖动时，polyline的轨迹pointsList没有进行整体移动，本次提交的改动可以修复这个缺陷