### PR TITLE
fix(core): snap the text pos of cloneNode to grid(#1545)

### DIFF
--- a/packages/core/__tests__/bugs/1545-spec.test.ts
+++ b/packages/core/__tests__/bugs/1545-spec.test.ts
@@ -1,0 +1,38 @@
+import type { NodeConfig, TextConfig } from '../../src/index';
+import { LogicFlow } from '../../src/index';
+
+type NodeConfigTextObj = NodeConfig & { text: TextConfig };
+describe('#1545', () => {
+  const dom = document.createElement('div');
+  dom.id = 'main-graph';
+  document.body.appendChild(dom);
+  const lf = new LogicFlow({
+    container: dom,
+    width: 1000,
+    height: 1000,
+    grid: true,
+  });
+
+  it('clone node text pos should snap to grid', () => {
+    lf.render({
+      nodes: [
+        {
+          id: 'node_id_1',
+          type: 'rect',
+          x: 300,
+          y: 300,
+          text: {
+            x: 32,
+            y: 19,
+            value: '文本1',
+          },
+        },
+      ],
+    });
+    const originNode = lf.getDataById('node_id_1') as NodeConfigTextObj;
+    const newNode = lf.cloneNode('node_id_1') as NodeConfigTextObj;
+    expect(originNode.x - originNode.text.x).toEqual(newNode.x - newNode.text.x);
+    expect(originNode.y - originNode.text.y).toEqual(newNode.y - newNode.text.y);
+    expect(originNode.text.value).toEqual(newNode.text.value);
+  });
+});

--- a/packages/core/__tests__/model/graphmodel.test.ts
+++ b/packages/core/__tests__/model/graphmodel.test.ts
@@ -1,0 +1,67 @@
+import type { NodeConfig, TextConfig } from '../../src/index';
+import { LogicFlow } from '../../src/index';
+
+type NodeConfigTextObj = NodeConfig & { text: TextConfig };
+describe('graphmodel', () => {
+  const dom = document.createElement('div');
+  dom.id = 'main-graph';
+  document.body.appendChild(dom);
+  const lf = new LogicFlow({
+    container: dom,
+    width: 1000,
+    height: 1000,
+    keyboard: {
+      enabled: true,
+    },
+    allowRotation: true,
+    metaKeyMultipleSelected: true,
+    grid: true,
+    snapline: true,
+  });
+
+  // 将node节点位置进行grid修正，同时处理node内文字的偏移量，返回一个位置修正过的复制节点NodeModel
+  test('getModelAfterSnapToGrid', () => {
+    const rawData = {
+      nodes: [
+        {
+          id: 'node1',
+          type: 'rect',
+          x: 111,
+          y: 123,
+          text: {
+            x: 32,
+            y: 19,
+            value: '文本1',
+          },
+        },
+      ],
+    };
+    lf.render(rawData);
+
+    const originNode = lf.getDataById('node1') as NodeConfigTextObj;
+
+    // grid=true 默认 gridSize=20
+    const newNode = lf.graphModel.getModelAfterSnapToGrid(originNode) as NodeConfigTextObj;
+    expect(originNode.x - originNode.text.x).toEqual(newNode.x - newNode.text.x);
+    expect(originNode.y - originNode.text.y).toEqual(newNode.y - newNode.text.y);
+    expect(originNode.text.value).toEqual(newNode.text.value);
+
+    lf.graphModel.gridSize = 40;
+    const newNode1 = lf.graphModel.getModelAfterSnapToGrid(originNode) as NodeConfigTextObj;
+    expect(originNode.x - originNode.text.x).toEqual(newNode1.x - newNode1.text.x);
+    expect(originNode.y - originNode.text.y).toEqual(newNode1.y - newNode1.text.y);
+    expect(originNode.text.value).toEqual(newNode1.text.value);
+
+    lf.graphModel.gridSize = 1;
+    const newNode2 = lf.graphModel.getModelAfterSnapToGrid(originNode) as NodeConfigTextObj;
+    expect(originNode.x - originNode.text.x).toEqual(newNode2.x - newNode2.text.x);
+    expect(originNode.y - originNode.text.y).toEqual(newNode2.y - newNode2.text.y);
+    expect(originNode.text.value).toEqual(newNode2.text.value);
+
+    lf.graphModel.gridSize = 17;
+    const newNode3 = lf.graphModel.getModelAfterSnapToGrid(originNode) as NodeConfigTextObj;
+    expect(originNode.x - originNode.text.x).toEqual(newNode3.x - newNode3.text.x);
+    expect(originNode.y - originNode.text.y).toEqual(newNode3.y - newNode3.text.y);
+    expect(originNode.text.value).toEqual(newNode3.text.value);
+  });
+});


### PR DESCRIPTION
fix [#1545](https://github.com/didi/LogicFlow/issues/1545)
fix [#1440](https://github.com/didi/LogicFlow/issues/1440)   => related: [transform相关问题汇总](https://github.com/didi/LogicFlow/issues/1446)


## 问题发生的原因

在`menu`鼠标右键点击复制时，会触发
```js
// packages/core/src/LogicFlow.tsx
cloneNode(nodeId) {
    const Model = this.graphModel.getNodeModelById(nodeId);
    const data = Model.getData();
    const { guards } = this.options;
    const enabledClone = guards && guards.beforeClone ? guards.beforeClone(data) : true;
    if (enabledClone) {
      return this.graphModel.cloneNode(nodeId);
    }
}
```
最终执行逻辑也就是`this.graphModel.cloneNode(nodeId)`
```js
// packages/core/src/model/GraphModel.ts
cloneNode(nodeId) {
  const Model = this.getNodeModelById(nodeId);
  const data = Model.getData();
  data.x += 30;
  data.y += 30;
  //...
  if (data.text) {
    data.text.x += 30;
    data.text.y += 30;
  }
  const nodeModel = this.addNode(data);
  //...
  return nodeModel.getData();
}
```

从上面代码可以知道，复制`node`时会增加`30`左右的偏移量，然后触发`this.addNode()`进行克隆节点的复制

```js
// packages/core/src/model/GraphModel.ts
function addNode(nodeConfig, eventType, event) {
  const nodeOriginData = formatData(nodeConfig);
  // 添加节点的时候，如果这个节点Id已经存在，则采用新的id
  if (nodeOriginData.id && this.nodesMap[nodeConfig.id]) {
    delete nodeOriginData.id;
  }
  const Model = this.getModel(nodeOriginData.type);
  if (!Model) {
    throw new Error(
      `找不到${nodeOriginData.type}对应的节点，请确认是否已注册此类型节点。`
    );
  }
  nodeOriginData.x = snapToGrid(nodeOriginData.x, this.gridSize);
  nodeOriginData.y = snapToGrid(nodeOriginData.y, this.gridSize);
  const nodeModel = new Model(nodeOriginData, this);
  this.nodes.push(nodeModel);
  const nodeData = nodeModel.getData();
  //...
  return nodeModel;
}
```

从上面`this.addNode()`方法可以知道，会对坐标进行一定的修正，也就是下面代码所示
```js
function snapToGrid(point, gridSize) {
  // 保证 x, y 的值为 gridSize 的整数倍
  return gridSize * Math.round(point / gridSize) || point;
}
```
因此问题就出在，当`this.gridSize`不为1时，`node.x`和`node.y`会根据`this.gridSize`进行一定的修正，但是`node.text.x`和`node.text.y`却没有进行根据`this.gridSize`进行一定的修正，导致了位置错误

而在`GraphModel.ts`的其它方法中，我们可以发现一些相似的代码，如下面代码所示
```js
// packages/core/src/model/GraphModel.ts
function graphDataToModel(graphData) {
  //...
  if (graphData.nodes) {
    this.nodes = map(graphData.nodes, (node) => {
      const Model = this.getModel(node.type);
      if (!Model) {
        throw new Error(`找不到${node.type}对应的节点。`);
      }
      const { x: nodeX, y: nodeY } = node;
      // 根据 grid 修正节点的 x, y
      if (nodeX && nodeY) {
        node.x = snapToGrid(nodeX, this.gridSize);
        node.y = snapToGrid(nodeY, this.gridSize);
        if (typeof node.text === "object") {
          node.text.x -= getGridOffset(nodeX, this.gridSize);
          node.text.y -= getGridOffset(nodeY, this.gridSize);
        }
      }
      return new Model(node, this);
    });
  } else {
    this.nodes = [];
  }
  //...
}
```

在执行`snapToGrid()`之后，是有进行`node.text.x -= getGridOffset(nodeX, this.gridSize)`，因此`#1545`的问题就在于，缺失了`node.text.x`和`node.text.y`根据`this.gridSize`进行一定坐标修正的逻辑

## 解决方法

### `node.text`进行`gridSize`的处理

将`graphDataToModel()`对`node.text.x`和`node.text.y`的处理补充到`addNode()`

```js
// packages/core/src/model/GraphModel.ts
function addNode(nodeConfig, eventType, event) {
  const nodeOriginData = formatData(nodeConfig);
  // 添加节点的时候，如果这个节点Id已经存在，则采用新的id
  if (nodeOriginData.id && this.nodesMap[nodeConfig.id]) {
    delete nodeOriginData.id;
  }
  const Model = this.getModel(nodeOriginData.type);
  if (!Model) {
    throw new Error(
      `找不到${nodeOriginData.type}对应的节点，请确认是否已注册此类型节点。`
    );
  }
  nodeOriginData.x = snapToGrid(nodeOriginData.x, this.gridSize);
  nodeOriginData.y = snapToGrid(nodeOriginData.y, this.gridSize);
  if (typeof node.text === "object") {
    node.text.x -= getGridOffset(nodeX, this.gridSize);
    node.text.y -= getGridOffset(nodeY, this.gridSize);
  }
  const nodeModel = new Model(nodeOriginData, this);
  this.nodes.push(nodeModel);
  const nodeData = nodeModel.getData();
  //...
  return nodeModel;
}
```

### 优化1

我们可以发现`graphDataToModel()`和`addNode()`中创建`new Model(nodeOriginData, this)`的代码一模一样，因此可以抽离出一个公共方法

```js
function getModelAfterSnapToGrid(node) {
  const Model = this.getModel(node.type);
  if (!Model) {
    throw new Error(
      `找不到${node.type}对应的节点，请确认是否已注册此类型节点。`
    );
  }
  const { x: nodeX, y: nodeY } = node;
  // 根据 grid 修正节点的 x, y
  if (nodeX && nodeY) {
    node.x = snapToGrid(nodeX, this.gridSize);
    node.y = snapToGrid(nodeY, this.gridSize);
    if (typeof node.text === "object") {
      node.text.x += node.x - nodeX;
      node.text.y += node.y - nodeY;
    }
  }
  return new Model(node, this);
}
```

### 优化2

> `getGridOffset()`存在一定的问题，可能会导致整体坐标计算错误

```js
node.x = snapToGrid(nodeX, this.gridSize);
node.y = snapToGrid(nodeY, this.gridSize);
if (typeof node.text === "object") {
  node.text.x -= getGridOffset(nodeX, this.gridSize);
  node.text.y -= getGridOffset(nodeY, this.gridSize);
}

function snapToGrid(point, gridSize) {
  // 保证 x, y 的值为 gridSize 的整数倍
  return gridSize * Math.round(point / gridSize) || point;
}
function getGridOffset(distance, gridSize) {
  return distance % gridSize;
}
```

我们发现一个问题，当初始化参数`grid=true`，此时`this.gridSize=20`
- 但是当`nodeX=29`时，`snapToGrid(29, 20)=20`，`getGridOffset(29, 20)=9`，`node`坐标从`29->20`，减少了`9`，`node.text`坐标也减少了9，这样结果是正确的
- 如果`nodeX=31`时，`snapToGrid(31, 20)=40`，`getGridOffset(31, 20)=11`，`node`坐标从`31->40`，增加了`9`，`node.text`坐标由于是`node.text.x -= getGridOffset(nodeX, this.gridSize)`，因此减少了11，这样的结果是错的

因此使用`Math.round()`这种四舍五入的做法，我们无法判断到底该`node.text.x -= getGridOffset(nodeX, this.gridSize)`还是`node.text.x += getGridOffset(nodeX, this.gridSize)`

```js
// 原来的处理是：node.text.x -= getGridOffset(nodeX, this.gridSize);
// 由于snapToGrid()使用了Math.round()四舍五入的做法，因此无法判断需要执行
// node.text.x = node.text.x + getGridOffset()
// 还是
// node.text.x = node.text.x - getGridOffset()
// 直接改为node.x - nodeX就可以满足上面的要求
node.text.x += (node.x - nodeX);
node.text.y += (node.y - nodeY);
```



## 单测

- 增加了`1545-spec.test.ts`简单模拟了下bug
- 增加`graphmodel.test.ts`对新增方法`getModelAfterSnapToGrid()`进行测试

### 未解决的问题

虽然单元测试能够`Pass`，但是最后会报错
![graphmodel](https://wbccb.github.io/Frontend-Articles/image/graphmodel.test.png)

测试了其它已经存在的单元测试，比如`packages/core/__tests__/logicflow.test.ts`，也存在这个问题
![graphmodel](https://wbccb.github.io/Frontend-Articles/image/logicflow.test.png)

暂时还没找到解决方法，后面有空的时候可能要集中处理下