### PR TITLE
fix(extension): trigger updateEdgePointByAnchors() after moveTo(#1384)

### DIFF
--- a/packages/extension/src/NodeResize/Control/Control.tsx
+++ b/packages/extension/src/NodeResize/Control/Control.tsx
@@ -384,14 +384,14 @@ class Control extends Component<IProps> {
    * 由于将拖拽放大缩小改成丝滑模式，这个时候需要在拖拽结束的时候，将节点的位置更新到grid上.
    */
   onDragEnd = () => {
-    // 先触发onDragging()->更新边->再触发用户自定义的getDefaultAnchor()，所以onDragging()拿到的anchors是滞后的
-    // 为了正确设置最终的位置，应该在拖拽结束的时候，再设置一次边的Point位置，此时拿到的anchors是最新的
-    this.updateEdgePointByAnchors();
-
     const { gridSize = 1 } = this.graphModel;
     const x = gridSize * Math.round(this.nodeModel.x / gridSize);
     const y = gridSize * Math.round(this.nodeModel.y / gridSize);
     this.nodeModel.moveTo(x, y);
+
+    // 先触发onDragging()->更新边->再触发用户自定义的getDefaultAnchor()，所以onDragging()拿到的anchors是滞后的
+    // 为了正确设置最终的位置，应该在拖拽结束的时候，再设置一次边的Point位置，此时拿到的anchors是最新的
+    this.updateEdgePointByAnchors();
   };
   render() {
     const {


### PR DESCRIPTION
related: [transform相关问题汇总](https://github.com/didi/LogicFlow/issues/1446)
fix: [#1384](https://github.com/didi/LogicFlow/issues/1384)
fix: [#1417](https://github.com/didi/LogicFlow/issues/1417)

## 前言
这次`pr`不是重构缩放、旋转等transform操作相关逻辑，只是一个简单的`bug修复`，因为这个`bug`的产生是因为我之前[pr#1205](https://github.com/didi/LogicFlow/pull/1205)疏忽大意导致的问题

## 问题发生的原因
在上次[pr#1205](https://github.com/didi/LogicFlow/pull/1205)中，我在`onDragEnd()`中增加了一行代码`this.updateEdgePointByAnchors()`，代表的意思是：更新目前node节点所有连接的edge的所有连接点，如下面所示

```js
// packages/extension/src/NodeResize/Control/Control.tsx
onDragEnd = () => {
       // 先触发onDragging()->更新边->再触发用户自定义的getDefaultAnchor()，所以onDragging()拿到的anchors是滞后的
       // 为了正确设置最终的位置，应该在拖拽结束的时候，再设置一次边的Point位置，此时拿到的anchors是最新的
+++   this.updateEdgePointByAnchors();

  
        const { gridSize = 1 } = this.graphModel;
        const x = gridSize * Math.round(this.nodeModel.x / gridSize);
        const y = gridSize * Math.round(this.nodeModel.y / gridSize);
        this.nodeModel.moveTo(x, y);
};
```
但是我加错位置了，我直接忽视了根据`gridSize`去修正`node`节点的相关`x`和`y`的代码，直接无视了`this.nodeModel.moveTo(x, y)`这么明显的代码

上面方法翻译过来就是
```js
// packages/extension/src/NodeResize/Control/Control.tsx
onDragEnd = () => {
    // 根据目前最新的anchor（依赖于最新的x和y坐标），然后去修正目前node和edge的连接点坐标

    // 根据gridSize去修正x和y坐标，然后moveTo()触发坐标更新->同时也会自动触发anchors的坐标更新
};
```

在触发`this.nodeModel.moveTo(x, y)`，应该再次触发一次`this.updateEdgePointByAnchors()`才对（如下面代码所示）
```js
// packages/extension/src/NodeResize/Control/Control.tsx
onDragEnd = () => {
  this.updateEdgePointByAnchors();

  const { gridSize = 1 } = this.graphModel;
  const x = gridSize * Math.round(this.nodeModel.x / gridSize);
  const y = gridSize * Math.round(this.nodeModel.y / gridSize);
  this.nodeModel.moveTo(x, y);
  this.updateEdgePointByAnchors();
};
```

简化后，就是`this.updateEdgePointByAnchors()`应该放在`this.nodeModel.moveTo(x, y)`之后，而不是之前

## 解决方法

```js
// packages/extension/src/NodeResize/Control/Control.tsx
onDragEnd = () => {
  this.updateEdgePointByAnchors();

  const { gridSize = 1 } = this.graphModel;
  const x = gridSize * Math.round(this.nodeModel.x / gridSize);
  const y = gridSize * Math.round(this.nodeModel.y / gridSize);
  this.nodeModel.moveTo(x, y);
};
```
改为

```js
// packages/extension/src/NodeResize/Control/Control.tsx
onDragEnd = () => {
  const { gridSize = 1 } = this.graphModel;
  const x = gridSize * Math.round(this.nodeModel.x / gridSize);
  const y = gridSize * Math.round(this.nodeModel.y / gridSize);
  this.nodeModel.moveTo(x, y);

  this.updateEdgePointByAnchors();
};
```