### PR TITLE
fix(extension): when group is click,calibrate the topGroupZIndex(#1535)

### DIFF
--- a/packages/extension/src/materials/group/index.ts
+++ b/packages/extension/src/materials/group/index.ts
@@ -357,19 +357,26 @@ class Group {
     // 当外部直接设置多个BaseNode.zIndex=1时
     // 当点击某一个node时，由于这个this.topGroupZIndex是从-10000开始计算的，this.topGroupZIndex+1也就是-9999
     // 这就造成当前点击的node的zIndex远远比其它node的zIndex小，因此造成zIndex错乱问题
-    if (nodeZIndex > DEFAULT_TOP_Z_INDEX) {
-      // 说明this.topGroupZIndex已经失去意义，代表不了目前最高zIndex的group，需要重新校准
-      const allGroupNodes = this.lf.graphModel.nodes
-        .filter((node: BaseNodeModel) => node.isGroup);
-      let max = this.topGroupZIndex;
-      for (let i = 0; i < allGroupNodes.length; i++) {
-        const groupNode = allGroupNodes[i];
-        if (groupNode.zIndex > max) {
-          max = groupNode.zIndex;
-        }
+    // if (nodeZIndex > DEFAULT_TOP_Z_INDEX) {
+
+    // 如果此时this.topGroupZIndex=-10000
+    // 然后此时一个node.zIndex=1，一个node.zIndex=-10000，一个node.zIndex=-9999
+    // 当点击node.zIndex=-10000时，此时node会变为node.zIndex=-9999
+    // 但是它还是比其它两个节点的zIndex小，也就是点击这个node还是无法让它zIndex最高
+    // 因此无法使用nodeZIndex > DEFAULT_TOP_Z_INDEX
+    // 或者 nodeZIndex > DEFAULT_BOTTOM_Z_INDEX
+    // 或者 nodeZIndex > this.topGroupZIndex
+    const allGroupNodes = this.lf.graphModel.nodes
+      .filter((node: BaseNodeModel) => node.isGroup);
+    let max = this.topGroupZIndex;
+    for (let i = 0; i < allGroupNodes.length; i++) {
+      const groupNode = allGroupNodes[i];
+      if (groupNode.zIndex > max) {
+        max = groupNode.zIndex;
       }
-      this.topGroupZIndex = max;
     }
+    this.topGroupZIndex = max;
+    // }
   };
   /**
    * 1. 分组节点默认在普通节点下面。


### PR DESCRIPTION
fix [#1535](https://github.com/didi/LogicFlow/issues/1535)

## 问题发生的原因

在[https://examples.logic-flow.cn/demo/dist/pool](https://examples.logic-flow.cn/demo/dist/pool)的调试中，发现两个`GroupNode`类型的`Node`数据的初始化`zIndex=1`

当点击右边的矩形时，会触发`node:click`方法，一共有两个地方
```js
// packages/core/src/view/node/BaseNode.tsx
handleClick = (e) => {
  //...
  if (model.isSelected && !isDoubleClick && isMultiple) {
    //...
  } else {
    graphModel.selectNodeById(model.id, isMultiple);
    eventOptions.isSelected = true;
    this.toFront();
  }
  //...
};
toFront() {
  const { model, graphModel } = this.props;
  if (model.autoToFront) {
    graphModel.toFront(model.id);
  }
}
```
由于`GroupNode`类型的`Node`默认`autoToFront=false`，因此不会触发上面代码中的`graphModel.toFront(model.id)`
```js
class GroupNodeModel extends RectResize.model {
  initNodeData(data) {
    //...
    this.autoToFront = false;
    //...
  }
}
```

除了`BaseNode.tsx`监听`node:click`之外，还有`Group`也监听`node:click`
```js
const DEFAULT_BOTTOM_Z_INDEX = -10000;
class Group {
   topGroupZIndex = DEFAULT_BOTTOM_Z_INDEX;
  constructor({ lf }) {
    lf.on("node:click", this.nodeSelected);
  }

  nodeSelected = ({ data, isMultiple, isSelected }) => {
    const nodeModel = this.lf.getNodeModelById(data.id);
    this.toFrontGroup(nodeModel);
    // 重置所有的group zIndex,防止group节点zIndex增长为正。
    if (this.topGroupZIndex > DEFAULT_TOP_Z_INDEX) {
      //...
    }
  };
  toFrontGroup = (model) => {
    if (!model || !model.isGroup) {
      return;
    }
    this.topGroupZIndex++;
    model.setZIndex(this.topGroupZIndex);
    if (model.children) {
      model.children.forEach((nodeId) => {
        const node = this.lf.getNodeModelById(nodeId);
        this.toFrontGroup(node);
      });
    }
  };
}
```
从上面代码我们可以清晰知道，当触发`toFrontGroup()`时，由于`GroupNode`类型`isGroup=true`，因此会继续往下走
- 此时`this.topGroupZIndex=-10000`，`this.topGroupZIndex++`之后就是`-9999`
- 然后`model.setZIndex(this.topGroupZIndex)`等于`model.setZIndex(-9999)`

但是我们要记住一个东西，两个`GroupNode`类型的`Node`数据的初始化`zIndex=1`，也就是说点击的`Node.zIndex变为-999`，但是未点击的`Node.zIndex还是1`，因此就造成了`#1535`视频中的假选状态，本质就是`点击Node的zIndex`低于`未点击Node的zIndex`，被盖住了


## 解决方法

我们从`this.topGroupZIndex`的字面含义就可以知道，其值代表着最顶部的`group`的`zIndex`，如果用户不在外部随便设置`zIndex`，`GroupNode`类型的`Node`数据默认初始化就是`this.zIndex = DEFAULT_BOTTOM_Z_INDEX=-10000`，也就是`this.topGroupZIndex`的初始化值

而`this.topGroupZIndex`的初始化值是`-10000`，外部设置了`zIndex=1`，因此导致了`this.topGroupZIndex`的作用消失了

因此我们增加一个校准方法
```ts
checkAndCorrectTopGroupZIndex = (nodeZIndex: number) => {
  if (nodeZIndex > DEFAULT_TOP_Z_INDEX) {
    // 说明this.topGroupZIndex已经失去意义，代表不了目前最高zIndex的group，需要重新校准
    const allGroupNodes = this.lf.graphModel.nodes.filter(
      (node: BaseNodeModel) => node.isGroup
    );
    let max = this.topGroupZIndex;
    for (let i = 0; i < allGroupNodes.length; i++) {
      const groupNode = allGroupNodes[i];
      if (groupNode.zIndex > max) {
        max = groupNode.zIndex;
      }
    }
    this.topGroupZIndex = max;
  }
};
```
把它放在`toFrontGroup()`之前，如下面所示，这样通过`checkAndCorrectTopGroupZIndex()`的校准，`this.topGroupZIndex`就等于所有`group`类型节点中最高的`zIndex`的值，然后再进行`this.toFrontGroup()`就可以完美将点击的node的zIndex再增加1！
> 当然，由于`this.topGroupZIndex `大于0了，因此会触发`重置所有的group zIndex`的一系列逻辑，不过这并不影响已经排序好的node之间的顺序，也就是点击的node仍然是最高zIndex！
```ts
nodeSelected = ({ data, isMultiple, isSelected }) => {
  const nodeModel = this.lf.getNodeModelById(data.id);
  this.checkAndCorrectTopGroupZIndex(nodeModel.zIndex);
  this.toFrontGroup(nodeModel);
  // 重置所有的group zIndex,防止group节点zIndex增长为正。
  if (this.topGroupZIndex > DEFAULT_TOP_Z_INDEX) {
    this.topGroupZIndex = DEFAULT_BOTTOM_Z_INDEX;
    const allGroups = this.lf.graphModel.nodes
      .filter((node) => node.isGroup)
      .sort((a, b) => a.zIndex - b.zIndex);
    let preZIndex = 0;
    for (let i = 0; i < allGroups.length; i++) {
      const group = allGroups[i];
      if (group.zIndex !== preZIndex) {
        this.topGroupZIndex++;
        preZIndex = group.zIndex;
      }
      group.setZIndex(this.topGroupZIndex);
    }
  }
  //...
};
```
### 去除判断条件

- 如果此时`this.topGroupZIndex=-10000`
- 然后此时一个`node.zIndex=1`，一个`node.zIndex=-10000`，一个`node.zIndex=-9999`
- 当点击`node.zIndex=-10000`时，此时node会变为`node.zIndex=-9999`
- 但是它还是比其它两个节点的zIndex小，也就是点击这个node还是无法让它zIndex最高
- 因此无法使用`nodeZIndex > DEFAULT_TOP_Z_INDEX` 或者 `nodeZIndex > DEFAULT_BOTTOM_Z_INDEX` 或者 `nodeZIndex > this.topGroupZIndex`

需要每次触发`node:click`进行`checkAndCorrectTopGroupZIndex()`的校验

```ts
checkAndCorrectTopGroupZIndex = (nodeZIndex: number) => {
//   if (nodeZIndex > DEFAULT_TOP_Z_INDEX) {
    const allGroupNodes = this.lf.graphModel.nodes.filter(
      (node: BaseNodeModel) => node.isGroup
    );
    let max = this.topGroupZIndex;
    for (let i = 0; i < allGroupNodes.length; i++) {
      const groupNode = allGroupNodes[i];
      if (groupNode.zIndex > max) {
        max = groupNode.zIndex;
      }
    }
    this.topGroupZIndex = max;
//   }
};
```

## 单元测试（暂无）
=_=一直报错，无法调通，有空再补，先把bug修复了