### PR TITLE
fix: 修复使用框选插件会阻塞页面滚轮事件问题

### DIFF
--- a/packages/core/src/tool/MultipleSelectTool.tsx
+++ b/packages/core/src/tool/MultipleSelectTool.tsx
@@ -32,6 +32,21 @@ export default class MultipleSelect extends Component<IProps> {
   handleMouseDown = (ev: MouseEvent) => {
     this.stepDrag.handleMouseDown(ev);
   };
+  handleWheelEvent = (ev: WheelEvent) => {
+    ev.preventDefault();
+    const { deltaX, deltaY, clientX, clientY, ctrlKey } = ev;
+    const newEvent = new WheelEvent('wheel', {
+      deltaX,
+      deltaY,
+      clientX,
+      clientY,
+      ctrlKey,
+    });
+    const { logicFlow } = this.props;
+    logicFlow.container
+      ?.querySelector('.lf-canvas-overlay[name="canvas-overlay"]')
+      ?.dispatchEvent(newEvent);
+  };
   onDragging = ({ deltaX, deltaY }) => {
     const { graphModel } = this.props;
     const selectElements = graphModel.getSelectElements(true);
@@ -98,6 +113,7 @@ export default class MultipleSelect extends Component<IProps> {
         style={style}
         onMouseDown={this.handleMouseDown}
         onContextMenu={this.handleContextMenu}
+        onWheel={this.handleWheelEvent}
       />
     );
   }

--- a/packages/extension/src/components/selection-select/index.ts
+++ b/packages/extension/src/components/selection-select/index.ts
@@ -58,7 +58,6 @@ class SelectionSelect {
       this.wrapper = wrapper;
       document.addEventListener('mousemove', this.__draw);
       document.addEventListener('mouseup', this.__drawOff);
-      document.addEventListener('wheel', this.__zoom, { passive: false });
     });
   }
   /**
@@ -142,17 +141,6 @@ class SelectionSelect {
       }
     });
     this.lf.emit('selection:selected', elements);
-  };
-  __zoom = (ev: WheelEvent) => {
-    ev.preventDefault();
-    const newEvent = new WheelEvent('wheel', {
-      deltaX: ev.deltaX,
-      deltaY: ev.deltaY,
-      clientX: ev.clientX,
-      clientY: ev.clientY,
-      ctrlKey: ev.ctrlKey,
-    });
-    this.lf.container?.querySelector('.lf-canvas-overlay[name="canvas-overlay"]')?.dispatchEvent(newEvent);
   };
   open() {
     this.__disabled = false;


### PR DESCRIPTION
fix #1614 
fix #1534 

之前兼容鼠标滚轮事件的方式会阻塞整个页面的滚轮事件，已修复