### PR TITLE
feat(extension): 支持导出节点中的网络图片

### DIFF
--- a/docs/guide/extension/snapshot.md
+++ b/docs/guide/extension/snapshot.md
@@ -69,6 +69,39 @@ const xml = lfJson2Xml(lf.getGraphData())
     }
   `
 ```
+
+### 支持导出节点中的网络图片
+
+支持导出的图片有标签 \<img>, \<image> 和样式属性 background, background-image
+写在 css 中的样式不能被正确导出, 需要以内联的方式设置样式。background 和 \<img> 示例如下：
+
+```js
+class UmlNode extends HtmlNode {
+  setHtml(rootEl) {
+    const { properties } = this.props.model;
+    const el = document.createElement('div');
+    el.className = 'uml-wrapper';
+    const html = `
+          <div>
+          <div class="uml-head">Head</div>
+          <div class="uml-body" style="width: 100px;height: 100px;background: url(https://cdn.jsdelivr.net/gh/towersxu/cdn@master/material/funny/%E6%88%90%E7%86%9F.jpg);background-size: cover;">
+          <div>+ ${properties.name}</div>
+          <div>+ ${properties.body}</div>
+          </div>
+          <div class="uml-footer demo1">
+          <div>+ setHead(Head $head)</div>
+          <div>+ setBody(Body $body)</div>
+          </div>
+          <img src="https://cdn.jsdelivr.net/gh/towersxu/cdn@master/material/funny/%E6%88%90%E7%86%9F.jpg" style="width: 50px;height: 50px;" />
+        </div>
+      `;
+    el.innerHTML = html;
+    rootEl.innerHTML = '';
+    rootEl.appendChild(el);
+  }
+  }
+```
+
 ### 示例
 
 <iframe src="https://codesandbox.io/embed/logicflow-base21-o3vqi?fontsize=14&hidenavigation=1&theme=dark&view=preview"

--- a/packages/extension/examples/snapshot/index.js
+++ b/packages/extension/examples/snapshot/index.js
@@ -9,7 +9,7 @@ window.onload = function () {
       control: true,
     },
     background: {
-      color: '#F0F0F0'
+      color: '#F0F0F0',
     },
     grid: {
       type: 'dot',
@@ -20,12 +20,12 @@ window.onload = function () {
         text: '分享',
         className: 'lf-menu-item',
         callback(graphModel) {
-          alert('分享')
+          alert('分享');
         },
-      }
+      },
     ],
     // nodeTextDraggable: true,
-    edgeTextDraggable: true
+    edgeTextDraggable: true,
   });
   const lf1 = new LogicFlow({
     container: document.querySelector('#app1'),
@@ -44,14 +44,14 @@ window.onload = function () {
         text: '分享',
         className: 'lf-menu-item',
         callback(graphModel) {
-          alert('分享')
+          alert('分享');
         },
-      }
+      },
     ],
     // nodeTextDraggable: true,
-    edgeTextDraggable: true
+    edgeTextDraggable: true,
   });
-  // 方便调试
+    // 方便调试
   window.lf = lf;
   window.lf1 = lf1;
   lf.setTheme({
@@ -61,7 +61,7 @@ window.onload = function () {
       lineHeight: 1.2,
       fontSize: 14,
     },
-  })
+  });
   class UserModel extends RectNodeModel {
   }
   class UserNode extends RectNode {
@@ -69,16 +69,16 @@ window.onload = function () {
   class UmlModel extends HtmlNodeModel {
     setAttributes() {
       const width = 200;
-      const height = 230;
+      const height = 280;
       this.width = width;
       this.height = height;
-      const properties = this.properties;
+      const { properties } = this;
       this.anchorsOffset = [
         [width / 2, 0],
         [0, height / 2],
         [-width / 2, 0],
-        [0, -height/2],
-      ]
+        [0, -height / 2],
+      ];
     }
   }
   class UmlNode extends HtmlNode {
@@ -87,32 +87,67 @@ window.onload = function () {
       const el = document.createElement('div');
       el.className = 'uml-wrapper';
       const html = `
-        <div>
-          <div class="uml-head">Head</div>
-          <div class="uml-body demo2">
-            <div>+ ${properties.name}</div>
-            <div>+ ${properties.body}</div>
-          </div>
-          <div class="uml-footer demo1">
-            <div>+ setHead(Head $head)</div>
-            <div>+ setBody(Body $body)</div>
-          </div>
-        </div>
-      `
+              <div>
+              <div class="uml-head">Head</div>
+              <div class="uml-body" style="width: 100px;height: 100px;background: url(https://cdn.jsdelivr.net/gh/towersxu/cdn@master/material/funny/%E6%88%90%E7%86%9F.jpg);background-size: cover;">
+              <div>+ ${properties.name}</div>
+              <div>+ ${properties.body}</div>
+              </div>
+              <div class="uml-footer demo1">
+              <div>+ setHead(Head $head)</div>
+              <div>+ setBody(Body $body)</div>
+              </div>
+              <img src="https://cdn.jsdelivr.net/gh/towersxu/cdn@master/material/funny/%E6%88%90%E7%86%9F.jpg" style="width: 50px;height: 50px;" />
+            </div>
+          `;
       el.innerHTML = html;
       rootEl.innerHTML = '';
       rootEl.appendChild(el);
     }
   }
+
+  class ImageModel extends RectNodeModel {
+    initNodeData(data) {
+      super.initNodeData(data);
+      this.width = 80;
+      this.height = 60;
+    }
+  }
+
+  class ImageNode extends RectNode {
+    getImageHref() {
+      return 'https://cdn.jsdelivr.net/gh/towersxu/cdn@master/material/funny/%E6%88%90%E7%86%9F.jpg';
+    }
+    getShape() {
+      const { x, y, width, height } = this.props.model;
+      const href = this.getImageHref();
+      const attrs = {
+        x: x - (1 / 2) * width,
+        y: y - (1 / 2) * height,
+        width,
+        height,
+        href,
+        // 根据宽高缩放
+        preserveAspectRatio: 'none meet',
+      };
+      return h('g', {}, [h('image', { ...attrs })]);
+    }
+  }
+
   lf.register({
     type: 'uml',
     view: UmlNode,
     model: UmlModel,
-  })
+  });
   lf.register({
     type: 'user',
     view: UserNode,
     model: UserModel,
+  });
+  lf.register({
+    type: 'image',
+    view: ImageNode,
+    model: ImageModel,
   });
   lf.render({
     nodes: [
@@ -123,8 +158,14 @@ window.onload = function () {
         id: 100,
         properties: {
           name: 'haod',
-          body: '哈哈哈哈'
-        }
+          body: '哈哈哈哈',
+        },
+      },
+      {
+        type: 'image',
+        x: 300,
+        y: 100,
+        id: 110,
       },
       {
         type: 'rect',
@@ -158,34 +199,34 @@ window.onload = function () {
           y: 300,
         },
         id: 12,
-      }
+      },
     ],
     edges: [
       {
         type: 'polyline',
         sourceNodeId: 10,
-        targetNodeId: 11
-      }
+        targetNodeId: 11,
+      },
     ],
   });
-  lf.extension.snapshot.useGlobalRules = false
+  lf.extension.snapshot.useGlobalRules = false;
   lf.extension.snapshot.customCssRules = `
-    .lf-node-text-auto-wrap-content{
-      line-height: 1.2;
-      background: transparent;
-      text-align: center;
-      word-break: break-all;
-      width: 100%;
-    }
-    .lf-canvas-overlay {
-      background: red;
-    }
-  `
+      .lf-node-text-auto-wrap-content{
+        line-height: 1.2;
+        background: transparent;
+        text-align: center;
+        word-break: break-all;
+        width: 100%;
+      }
+      .lf-canvas-overlay {
+        background: red;
+      }
+    `;
   lf1.register({
     type: 'uml',
     view: UmlNode,
     model: UmlModel,
-  })
+  });
   lf1.register({
     type: 'user',
     view: UserNode,
@@ -214,51 +255,51 @@ window.onload = function () {
           y: 300,
         },
         id: 12,
-      }
-    ]
+      },
+    ],
   });
-  lf1.extension.snapshot.useGlobalRules = false
+  lf1.extension.snapshot.useGlobalRules = false;
   lf1.extension.snapshot.customCssRules = `
-    .lf-node-text-auto-wrap-content{
-      line-height: 1.2;
-      background: transparent;
-      text-align: center;
-      word-break: break-all;
-      width: 100%;
-    }
-    .lf-canvas-overlay {
-      background: red;
-    }
-  `
-}
+      .lf-node-text-auto-wrap-content{
+        line-height: 1.2;
+        background: transparent;
+        text-align: center;
+        word-break: break-all;
+        width: 100%;
+      }
+      .lf-canvas-overlay {
+        background: red;
+      }
+    `;
+};
 document.getElementById('download').addEventListener('click', () => {
-  lf.getSnapshot()
-})
+  lf.getSnapshot();
+});
 document.getElementById('download1').addEventListener('click', () => {
-  lf1.getSnapshot()
-})
+  lf1.getSnapshot();
+});
 document.getElementById('preview').addEventListener('click', () => {
-  lf.getSnapshotBlob('#FFFFFF').then(({data, width, height})=> {
+  lf.getSnapshotBlob('#FFFFFF').then(({ data, width, height }) => {
     document.getElementById('img').src = img.src = window.URL.createObjectURL(data);
-    console.log(width, height)
-  })
-})
+    console.log(width, height);
+  });
+});
 document.getElementById('base64').addEventListener('click', () => {
-  lf.getSnapshotBase64().then(({data, width, height}) => {
+  lf.getSnapshotBase64().then(({ data, width, height }) => {
     document.getElementById('img').src = data;
-    console.log(width, height)
-  })
-})
+    console.log(width, height);
+  });
+});
 
-document.querySelector("#downloadXml").addEventListener("click", () => {
+document.querySelector('#downloadXml').addEventListener('click', () => {
   const data = lf.getGraphData();
   console.log(lfJson2Xml(data));
   download('logicflow.xml', lfJson2Xml(data));
-})
+});
 
 function download(filename, text) {
-  var element = document.createElement('a');
-  element.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(text));
+  const element = document.createElement('a');
+  element.setAttribute('href', `data:text/plain;charset=utf-8,${encodeURIComponent(text)}`);
   element.setAttribute('download', filename);
 
   element.style.display = 'none';

--- a/packages/extension/src/tools/snapshot/index.ts
+++ b/packages/extension/src/tools/snapshot/index.ts
@@ -1,5 +1,129 @@
 /* eslint-disable operator-linebreak */
 /* eslint-disable implicit-arrow-linebreak */
+
+/**
+ * 图片缓存, 已请求过的图片直接从缓存中获取
+ */
+const imageCache: Record<string, string> = {};
+
+/**
+ * 当获取图片失败时会返回失败信息，是 text/plain 类型的数据
+ * @param str - 图片内容
+ * @returns
+ */
+function isTextPlainBase64(str: string) {
+  return str.startsWith('data:text/plain');
+}
+
+/**
+ * 将网络图片转为 base64
+ * @param url - 图片地址
+ * @returns
+ */
+async function convertImageToBase64(url: string): Promise<string> {
+  if (imageCache[url]) {
+    return imageCache[url];
+  }
+  return fetch(url)
+    .then((response) => response.blob())
+    .then(
+      (blob) =>
+        new Promise((resolve, reject) => {
+          const reader = new FileReader();
+          reader.onloadend = () => resolve(reader.result as string);
+          reader.onerror = reject;
+          reader.readAsDataURL(blob);
+        }),
+    );
+}
+
+/**
+ * 使用 base64 的图片替换 img 标签的 src 或 image 标签的 href
+ * @param node - html 节点或 svg 节点
+ */
+async function updateImageSrcOrHrefWithBase64Image(
+  node: HTMLImageElement | SVGImageElement,
+  attrName: 'src' | 'href',
+) {
+  try {
+    const url = node.getAttribute(attrName) || '';
+    // 已经是 base64 图片，不需要处理
+    if (url.startsWith('data:')) {
+      return;
+    }
+    const base64Image = await convertImageToBase64(url);
+    if (isTextPlainBase64(base64Image)) {
+      return;
+    }
+    node.setAttribute(attrName, base64Image);
+  } catch (error) {
+    console.error(error);
+  }
+}
+
+/**
+ * 使用 base64 的图片替换背景图片
+ * @param node - html 节点
+ * @param styleAttr - 样式属性名称
+ */
+async function updateBackgroundImageWithBase64Image(
+  node: HTMLElement,
+  url: string,
+) {
+  try {
+    // 已经是 base64 图片，不需要处理
+    if (url.startsWith('data:')) {
+      return;
+    }
+    const base64Image = await convertImageToBase64(url);
+    if (isTextPlainBase64(base64Image)) {
+      return;
+    }
+    node.style.backgroundImage = `url(${base64Image})`;
+  } catch (error) {
+    console.error(error);
+  }
+}
+
+/**
+ * 更新图片数据
+ * @param node - 节点
+ */
+async function updateImageSource(node: HTMLElement | SVGElement) {
+  const nodes = [node];
+  let nodePtr;
+  const promises: any[] = [];
+  while (nodes.length) {
+    nodePtr = nodes.shift();
+    if (nodePtr.children.length) {
+      nodes.push(...nodePtr.children);
+    }
+    if (nodePtr instanceof HTMLElement) {
+      // 如果有 style 的 background, backgroundImage 属性中有 url(xxx), 尝试替换为 base64 图片
+      const { background, backgroundImage } = nodePtr.style;
+      const backgroundUrlMatch = background.match(/url\(["']?(.*?)["']?\)/);
+      if (backgroundUrlMatch && backgroundUrlMatch[1]) {
+        const imageUrl = backgroundUrlMatch[1];
+        promises.push(updateBackgroundImageWithBase64Image(nodePtr, imageUrl));
+      }
+      const backgroundImageUrlMatch = backgroundImage.match(
+        /url\(["']?(.*?)["']?\)/,
+      );
+      if (backgroundImageUrlMatch && backgroundImageUrlMatch[1]) {
+        const imageUrl = backgroundImageUrlMatch[1];
+        promises.push(updateBackgroundImageWithBase64Image(nodePtr, imageUrl));
+      }
+    }
+    // 如果有 img 和 image 标签，尝试将 src 和 href 替换为 base64 图片
+    if (nodePtr instanceof HTMLImageElement) {
+      promises.push(updateImageSrcOrHrefWithBase64Image(nodePtr, 'src'));
+    } else if (nodePtr instanceof SVGImageElement) {
+      promises.push(updateImageSrcOrHrefWithBase64Image(nodePtr, 'href'));
+    }
+  }
+  await Promise.all(promises);
+}
+
 /**
  * 快照插件，生成视图
  */
@@ -71,9 +195,10 @@ class Snapshot {
     }
   }
   /* 下载图片 */
-  getSnapshot(fileName: string, backgroundColor: string) {
+  async getSnapshot(fileName: string, backgroundColor: string) {
     this.fileName = fileName || `logic-flow.${Date.now()}.png`;
     const svg = this.getSvgRootElement(this.lf);
+    await updateImageSource(svg);
     this.getCanvasData(svg, backgroundColor).then(
       (canvas: HTMLCanvasElement) => {
         const imgURI = canvas
@@ -84,8 +209,9 @@ class Snapshot {
     );
   }
   /* 获取base64对象 */
-  getSnapshotBase64(backgroundColor: string) {
+  async getSnapshotBase64(backgroundColor: string) {
     const svg = this.getSvgRootElement(this.lf);
+    await updateImageSource(svg);
     return new Promise((resolve) => {
       this.getCanvasData(svg, backgroundColor).then(
         (canvas: HTMLCanvasElement) => {
@@ -97,8 +223,9 @@ class Snapshot {
     });
   }
   /* 获取Blob对象 */
-  getSnapshotBlob(backgroundColor: string) {
+  async getSnapshotBlob(backgroundColor: string) {
     const svg = this.getSvgRootElement(this.lf);
+    await updateImageSource(svg);
     return new Promise((resolve) => {
       this.getCanvasData(svg, backgroundColor).then(
         (canvas: HTMLCanvasElement) => {


### PR DESCRIPTION
关联的 issue: resolve  #477 resolve #1076 
Snapshot 插件支持导出节点中的网络图片。
之前按照 issue 中的建议，使用 html2Canvas 和 dom-to-image 均无法正确导出节点中的图片。
在公司项目开发中通过在调用 getSnapshot() 之前将 <img> <image> 标签的图片替换成 base64 字符串, 将 style 中的 background, background-image 替换成 base64 字符串, 可以正确导出节点中的图片。
本次 pr 将替换网络图片为 base64 的功能集成到 Snapshot 插件中，开发者遵循文档中的使用方法即可正确导出网络图片。
测试范围覆盖了 getSnapshot, getSnapshotBase64, getSnapshotBlob, 均成功导出带有网络图片的节点。
![image](https://github.com/didi/LogicFlow/assets/37300913/5fc5afab-a197-4a86-a656-c84a51d22b8a)
