### PR TITLE
fix(core): unexpected behavior caused by rotation

### DIFF
--- a/examples/feature-examples/src/pages/graph/index.tsx
+++ b/examples/feature-examples/src/pages/graph/index.tsx
@@ -16,6 +16,7 @@ const config: Partial<LogicFlow.Options> = {
   isSilentMode: false,
   stopScrollGraph: true,
   stopZoomGraph: true,
+  allowResize: true,
   style: {
     rect: {
       rx: 5,
@@ -76,7 +77,7 @@ const data = {
   nodes: [
     {
       id: 'custom-node-1',
-      rotate: 1.1722738811284763,
+      rotate: Math.PI / 6,
       text: {
         x: 600,
         y: 200,

--- a/packages/core/src/model/node/BaseNodeModel.ts
+++ b/packages/core/src/model/node/BaseNodeModel.ts
@@ -247,9 +247,7 @@ export class BaseNodeModel implements IBaseNodeModel {
    * 计算节点 resize 时
    */
   resize(resizeInfo: ResizeInfo): ResizeNodeData {
-    const { width, height, deltaX, deltaY } = resizeInfo
-    // 移动节点以及文本内容
-    this.move(deltaX / 2, deltaY / 2)
+    const { width, height } = resizeInfo
 
     this.width = width
     this.height = height

--- a/packages/core/src/model/node/CircleNodeModel.ts
+++ b/packages/core/src/model/node/CircleNodeModel.ts
@@ -73,9 +73,7 @@ export class CircleNodeModel extends BaseNodeModel {
   }
 
   resize(resizeInfo: ResizeInfo): ResizeNodeData {
-    const { width, deltaX, deltaY } = resizeInfo
-    // 移动节点以及文本内容
-    this.move(deltaX / 2, deltaY / 2)
+    const { width } = resizeInfo
 
     this.r = width
     this.setProperties({

--- a/packages/core/src/model/node/DiamondNodeModel.ts
+++ b/packages/core/src/model/node/DiamondNodeModel.ts
@@ -110,9 +110,7 @@ export class DiamondNodeModel extends BaseNodeModel {
   }
 
   resize(resizeInfo: ResizeInfo): ResizeNodeData {
-    const { width, height, deltaX, deltaY } = resizeInfo
-    // 移动节点以及文本内容
-    this.move(deltaX / 2, deltaY / 2)
+    const { width, height } = resizeInfo
 
     this.rx = width
     this.ry = height

--- a/packages/core/src/model/node/EllipseNodeModel.ts
+++ b/packages/core/src/model/node/EllipseNodeModel.ts
@@ -76,9 +76,7 @@ export class EllipseNodeModel extends BaseNodeModel {
   }
 
   resize(resizeInfo: ResizeInfo): ResizeNodeData {
-    const { width, height, deltaX, deltaY } = resizeInfo
-    // 移动节点以及文本内容
-    this.move(deltaX / 2, deltaY / 2)
+    const { width, height } = resizeInfo
 
     this.rx = width
     this.ry = height

--- a/packages/core/src/model/node/PolygonNodeModel.ts
+++ b/packages/core/src/model/node/PolygonNodeModel.ts
@@ -125,9 +125,7 @@ export class PolygonNodeModel extends BaseNodeModel {
   }
 
   resize(resizeInfo: ResizeInfo): ResizeNodeData {
-    const { width, height, deltaX, deltaY } = resizeInfo
-    // 移动节点以及文本内容
-    this.move(deltaX / 2, deltaY / 2)
+    const { width, height } = resizeInfo
 
     const nextPoints: PointTuple[] = map(this.points, ([x, y]) => [
       (x * width) / this.width,

--- a/packages/core/src/view/Control.tsx
+++ b/packages/core/src/view/Control.tsx
@@ -60,13 +60,13 @@ export class ResizeControl extends Component<
     // https://github.com/didi/LogicFlow/issues/807
     // https://github.com/didi/LogicFlow/issues/875
     // 之前的做法，比如Rect是使用getRectResizeEdgePoint()计算边的point缩放后的位置
-    // getRectResizeEdgePoint()考虑了瞄点在四条边以及在4个圆角的情况
+    // getRectResizeEdgePoint()考虑了锚点在四条边以及在4个圆角的情况
     // 使用的是一种等比例缩放的模式，比如：
     // const pct = (y - beforeNode.y) / (beforeNode.height / 2 - radius)
     // afterPoint.y = afterNode.y + (afterNode.height / 2 - radius) * pct
     // 但是用户自定义的getDefaultAnchor()不一定是按照比例编写的
-    // 它可能是 x: x + 20：每次缩放都会保持在x右边20的位置，因此用户自定义瞄点时，然后产生无法跟随的问题
-    // 现在的做法是：直接获取用户自定义瞄点的位置，然后用这个位置作为边的新的起点，而不是自己进行计算
+    // 它可能是 x: x + 20：每次缩放都会保持在x右边20的位置，因此用户自定义锚点时，然后产生无法跟随的问题
+    // 现在的做法是：直接获取用户自定义锚点的位置，然后用这个位置作为边的新的起点，而不是自己进行计算
     const { id, anchors } = this.nodeModel
     const edges = this.graphModel.getNodeEdges(id)
     // 更新边
@@ -294,11 +294,17 @@ export class ResizeControl extends Component<
 
   onDragging = ({ deltaX, deltaY }: IDragParams) => {
     const { transformModel } = this.graphModel
+    const {
+      model: { rotate = 0 },
+    } = this.props
     const [dx, dy] = transformModel.fixDeltaXY(deltaX, deltaY)
 
+    const tDx = dx * Math.cos(rotate) + dy * Math.sin(rotate)
+    const tDy = -dx * Math.sin(rotate) + dy * Math.cos(rotate)
+
     this.resizeNode({
-      deltaX: dx,
-      deltaY: dy,
+      deltaX: tDx,
+      deltaY: tDy,
     })
   }
 


### PR DESCRIPTION
修复旋转与缩放同时使用时锚点错误的问题

- 节点resize后，不再需要move，因为旋转和缩放都不会改变节点中心点坐标
- 通过控制点进行缩放，如果已经发生了旋转，deltaX和deltaY需要根据旋转角度进一步计算，应用<img width="350" alt="截屏2024-07-02 18 58 48" src="https://github.com/didi/LogicFlow/assets/56008486/e9261185-369a-4c48-906f-6349c3137c06">

关联issue #1628 #1428 