### PR TITLE
docs: 官网api平铺展示进行分类

### DIFF
--- a/sites/docs/docs/api/detail/index.en-US.md
+++ b/sites/docs/docs/api/detail/index.en-US.md
@@ -5,48 +5,48 @@ table td:first-of-type {
 }
 </style>
 
-## register
+## Register Related
 
-Register nodes, edges.
+### register
+
+Register custom nodes, edges.
 
 ```jsx | pure
-lf.register(config):void
+lf.register(config: RegisterConfig):void
 ```
 
 Parameters:
 
-| Parameter Name | Type   | Required | Default | Description      |
+| Name | Type   | Required | Default | Description      |
 | :------------- | :----- | :------- | :------ | :------------------------------------- |
-| config.type    | String | ✅       | -       | Customize the names of nodes and edges |
+| config.type    | String | ✅       | -       | Customize the types of nodes and edges |
 | config.model   | Model  | ✅       | -       | Model of nodes and edges    |
 | config.view    | View   | ✅       | -       | View of nodes and edges     |
 
 Example:
 
 ```jsx | pure
-import { RectNode, RectNodeModel, h } from "@logicflow/core";
+import { RectNode, RectNodeModel } from "@logicflow/core";
 // provide nodes
-class UserNode extends RectNode {}
+class CustomRectNode extends RectNode {}
 // provide the attributes of the node
-class UserModel extends RectNodeModel {
-  constructor(data) {
-    super(data);
-    const { size } = data.properties;
-    this.width = size * 40;
-    this.height = size * 40;
-    this.fill = "green";
+class CustomRectModel extends RectNodeModel {
+  setAttributes() {
+    this.width = 200;
+    this.height = 80;
+    this.radius = 50;
   }
 }
 lf.register({
-  type: "user",
-  view: UserNode,
-  model: UserModel,
+  type: "Custom-rect",
+  view: CustomRectNode,
+  model: CustomRectModel,
 });
 ```
 
-## batchRegister
+### batchRegister
 
-Batch register
+Batch register.
 
 ```jsx | pure
 lf.batchRegister([
@@ -63,73 +63,9 @@ lf.batchRegister([
 );
 ```
 
-## render
+## Node Related
 
-Render graph data
-
-```jsx | pure
-const lf = new LogicFlow({
-  ...
-})
-lf.render(graphData)
-```
-
-## renderRawData
-
-Rendering of the raw graph data. The difference with `render` is that after using `adapter`, you can use this method if you still want to render the data in logicflow format.
-
-```jsx | pure
-const lf = new LogicFlow({
-  ...
-})
-lf.renderRawData({
-  nodes: [],
-  edges: []
-})
-```
-
-## setTheme
-
-Set the theme, see [Theme](theme-api) for details
-
-## changeNodeType
-
-Modify node type
-
-```jsx | pure
-changeNodeType(id: string, type: string): void
-```
-
-| Name | Type   | Required | Default | Description |
-| :--- | :----- | :------- | :------ | :---------- |
-| id   | String | ✅       |         | Node id     |
-| type | String | ✅       |         | New type    |
-
-Example:
-
-```jsx | pure
-lf.changeNodeType("node_id", "rect");
-```
-
-## getNodeEdges
-
-Get the model of all edges connected by the node.
-
-```jsx | pure
-getNodeEdges(id: string): BaseEdgeModel[]
-```
-
-| Parameter | Type   | Required | Default | Description |
-| :-------- | :----- | :------- | :------ | :---------- |
-| id        | String | ✅       |         | Node id     |
-
-Example：
-
-```jsx | pure
-const edgeModels = lf.getNodeEdges("node_id");
-```
-
-## addNode
+### addNode
 
 Add nodes to the graph.
 
@@ -167,7 +103,7 @@ lf.addNode({
 });
 ```
 
-## deleteNode
+### deleteNode
 
 Deletes a node on the graph, and if there is a line attached to this node, then also deletes the line.
 
@@ -187,7 +123,9 @@ Example：
 lf.deleteNode("id");
 ```
 
-## cloneNode
+### cloneNode
+
+Clone a node.
 
 ```jsx | pure
 cloneNode(nodeId: string): BaseNodeModel
@@ -205,7 +143,7 @@ Example：
 lf.cloneNode("id");
 ```
 
-## changeNodeId
+### changeNodeId
 
 Modify the id of the node, if no new id is passed, one will be created internally automatically.
 
@@ -215,9 +153,28 @@ Example：
 lf.changeNodeId("oldId", "newId");
 ```
 
-## getNodeModelById
+### changeNodeType
 
-Get the `model` of the node
+Modify node type.
+
+```jsx | pure
+changeNodeType(id: string, type: string): void
+```
+
+| Name | Type   | Required | Default | Description |
+| :--- | :----- | :------- | :------ | :---------- |
+| id   | String | ✅       |         | Node id     |
+| type | String | ✅       |         | New type    |
+
+Example:
+
+```jsx | pure
+lf.changeNodeType("node_id", "rect");
+```
+
+### getNodeModelById
+
+Get the `model` of the node.
 
 ```jsx | pure
 getNodeModelById(nodeId: string): BaseNodeModel
@@ -235,9 +192,9 @@ Example：
 lf.getNodeModelById("id");
 ```
 
-## getNodeDataById
+### getNodeDataById
 
-Get the `model` data of the node
+Get the `model` data of the node.
 
 ```jsx | pure
 getNodeDataById(nodeId: string): NodeConfig
@@ -255,9 +212,9 @@ Example：
 lf.getNodeDataById("id");
 ```
 
-## getNodeIncomingNode
+### getNodeIncomingNode
 
-Get all parent nodes of the node
+Get all parent nodes of the node.
 
 ```jsx | pure
 getNodeIncomingNode(nodeId: string): BaseNodeModel[]
@@ -269,9 +226,9 @@ Parameters:
 | :----- | :----- | :--- | :----- | :------ |
 | nodeId | String | ✅   | -      | Node id |
 
-## getNodeOutgoingNode
+### getNodeOutgoingNode
 
-Get all the next-level nodes of the node
+Get all the next-level nodes of the node.
 
 ```jsx | pure
 getNodeOutgoingNode(nodeId: string): BaseNodeModel[]
@@ -283,9 +240,9 @@ Parameters:
 | :----- | :----- | :--- | :----- | :------ |
 | nodeId | String | ✅   | -      | Node id |
 
-## getNodeIncomingEdge
+### getNodeIncomingEdge
 
-Get all the edges that end at this node
+Get all the edges that `end` at this node.
 
 ```jsx | pure
 getNodeIncomingEdge(nodeId: string): BaseEdgeModel[]
@@ -297,9 +254,9 @@ Parameters:
 | :----- | :----- | :--- | :----- | :------ |
 | nodeId | String | ✅   | -      | Node id |
 
-## getNodeOutgoingEdge
+### getNodeOutgoingEdge
 
-Get all the edges that start at this node
+Get all the edges that `start` at this node.
 
 ```jsx | pure
 getNodeOutgoingEdge(nodeId: string): BaseEdgeModel[]
@@ -311,9 +268,29 @@ Parameters:
 | :----- | :----- | :--- | :----- | :------ |
 | nodeId | String | ✅   | -      | Node id |
 
-## addEdge
+## Edge Related
 
-Create an edge connecting two nodes
+### setDefaultEdgeType
+
+Set the type of edge, i.e. set the type of linkage drawn directly by the user at the node.
+
+```jsx | pure
+setDefaultEdgeType(type: EdgeType): void
+```
+
+| Name       | Type   | Required | Default | Description             |
+| :--- | :----- | :--- | :--------- | :---------------------------------- |
+| type | String | ✅   | 'polyline' | Set the type of edge, built-in support for edge types are line (straight line), polyline (line), bezier (Bezier curve). The default is a line, and users can customize the type name to switch to the user-defined edge |
+
+Example：
+
+```jsx | pure
+lf.setDefaultEdgeType("line");
+```
+
+### addEdge
+
+Create an edge connecting two nodes.
 
 ```jsx | pure
 addEdge(edgeConfig: EdgeConifg): void
@@ -349,126 +326,9 @@ lf.addEdge({
 });
 ```
 
-## deleteEdge
+### getEdgeDataById
 
-Delete an edge based on its id
-
-```jsx | pure
-deleteEdge(id): void
-```
-
-Parameters:
-
-| Name       | Type   | Required | Default | Description        |
-| :--- | :----- | :--- | :----- | :------ |
-| id   | String |      | -      | Edge id |
-
-Example：
-
-```jsx | pure
-lf.deleteEdge("edge_1");
-```
-
-## deleteEdgeByNodeId
-
-Deletes an edge of the specified type, based on the start and end points of the edge, and can pass only one of them.
-
-```jsx | pure
-deleteEdgeByNodeId(config: EdgeFilter): void
-```
-
-Parameters:
-
-| Name       | Type   | Required | Default | Description           |
-| :----------- | :----- | :--- | :----- | :-------------- |
-| sourceNodeId | String |          | -       | id of the starting node of the edge |
-| targetNodeId | String |          | -       | id of the ending node of the edge   |
-
-Example：
-
-```jsx | pure
-
-lf.deleteEdgeByNodeId({
-  sourceNodeId: "id1",
-  targetNodeId: "id2",
-});
-
-lf.deleteEdgeByNodeId({
-  sourceNodeId: "id1",
-});
-
-lf.deleteEdgeByNodeId({
-  targetNodeId: "id2",
-});
-```
-
-## getEdgeModelById
-
-Get the `model` of the edge based on the its id
-
-```jsx | pure
-getEdgeModelById(edgeId: string): BaseEdgeModel
-```
-
-Parameters:
-
-| Name | Type | Mandatory | Default | Description    |
-| :----- | :----- | :--- | :----- | :------ |
-| edgeId | String | ✅   | -      | Node id |
-
-Example：
-
-```jsx | pure
-lf.getEdgeModelById("id");
-```
-
-## getEdgeModels
-
-Get the model of the edge that satisfies the condition
-
-| Name       | Type   | Required | Default | Description        |
-| :--------- | :----- | :--- | :----- | :------- |
-| edgeFilter | Object | ✅   | -      | Filtering conditions |
-
-```jsx | pure
-// get all the mods of the edges whose starting point is node A
-lf.getEdgeModels({
-  sourceNodeId: "nodeA_id",
-});
-// get all the mods of the edges whose ending point is node B
-lf.getEdgeModels({
-  targetNodeId: "nodeB_id",
-});
-// Get the edge whose starting point is node A and ending point is node B
-lf.getEdgeModels({
-  sourceNodeId: "nodeA_id",
-  targetNodeId: "nodeB_id",
-});
-```
-
-## changeEdgeId
-
-Modify the edge id. If a new id is not passed, one will be created internally automatically.
-
-Example：
-
-```jsx | pure
-lf.changeEdgeId("oldId", "newId");
-```
-
-## changeEdgeType
-
-Switch type of edge
-
-Example：
-
-```jsx | pure
-lf.changeEdgeType("edgeId", "bezier");
-```
-
-## getEdgeDataById
-
-Get edge data by `id`
+Get edge data by `id`.
 
 ```jsx | pure
 getEdgeDataById(edgeId: string): EdgeConfig
@@ -508,245 +368,146 @@ Example：
 lf.getEdgeDataById("id");
 ```
 
-## setDefaultEdgeType
+### getEdgeModelById
 
-Set the type of edge, i.e. set the type of linkage drawn directly by the user at the node.
-
-```jsx | pure
-setDefaultEdgeType(type: EdgeType): void
-```
-
-| Name       | Type   | Required | Default | Description             |
-| :--- | :----- | :--- | :--------- | :---------------------------------- |
-| type | String | ✅   | 'polyline' | Set the type of edge, built-in support for edge types are line (straight line), polyline (line), bezier (Bezier curve). The default is a line, and users can customize the type name to switch to the user-defined edge |
-
-Example：
+Get the `model` of the edge based on the its id.
 
 ```jsx | pure
-lf.setDefaultEdgeType("line");
+getEdgeModelById(edgeId: string): BaseEdgeModel
 ```
-
-## editText
-
-same as [graphModel.editText](graph-model-api#edittext)
-
-## updateText
-
-Update the node or edge text
-
-```jsx | pure
-updateText(id: string, value: string): void
-```
-
-| Name       | Type   | Required | Default | Description              |
-| :---- | :----- | :--- | :----- | :------------- |
-| id    | String | ✅   |        | Node or Edge id  |
-| value | String | ✅   |        | Updated text values |
-
-Example：
-
-```jsx | pure
-lf.updateText("id", "value");
-```
-
-## deleteElement
-
-```jsx | pure
-deleteElement(id: string): boolean
-```
-
-| Name       | Type   | Required | Default | Description              |
-| :--- | :----- | :--- | :----- | :------------ |
-| id   | String | ✅   |        | Node or Edge id |
-
-Example：
-
-```jsx | pure
-lf.deleteElement("node_id");
-```
-
-## selectElementById
-
-Select the graph
 
 Parameters:
 
-| Name       | Type   | Required | Default | Description                                                  |
-| :------- | :------ | :--- | :----- | :----------------------- |
-| id       | string  | ✅   | -      | Node or edge id                                    |
-| multiple | boolean |      | false  | If or not is multi-selected, if true, the last selected element will not be reset. |
-| toFront  | boolean |      | true   | If or not the selected element will be topped, default is true.   |
+| Name | Type | Mandatory | Default | Description    |
+| :----- | :----- | :--- | :----- | :------ |
+| edgeId | String | ✅   | -      | Node id |
 
 Example：
 
 ```jsx | pure
-lf.selectElementById(id: string, multiple = false, toFront = true)
+lf.getEdgeModelById("id");
 ```
 
-## getGraphData
+### getEdgeModels
 
-Get flow graphing data
+Get the model of the edge that satisfies the condition.
 
-```jsx | pure
-// Return value. If the adapter plugin is applied and the setting is adapterOut, the return is the converted data format, otherwise it is the default format.
-// Starting from version 1.2.5, new input parameters have been added for the execution of certain adapterOut that require input parameters.
-// For example, the built-in BpmnAdapter may require an array of attribute reserve fields to be passed in to ensure that certain node attributes in the exported data are properly processed.
-// The input parameters here should be consistent with the other parameters of the adapterOut method from the imported adapter, except for the data parameter.
-getGraphData(...params: any): GraphConfigData | unknown
-```
-
-LogicFlow default data format
+| Name       | Type   | Required | Default | Description        |
+| :--------- | :----- | :--- | :----- | :------- |
+| edgeFilter | Object | ✅   | -      | Filtering conditions |
 
 ```jsx | pure
-type GraphConfigData = {
-  nodes: {
-    id?: string;
-    type: string;
-    x: number;
-    y: number;
-    text?: TextConfig;
-    properties?: Record<string, unknown>;
-    zIndex?: number;
-  }[];
-  edges: {
-    id: string;
-    type: string;
-    sourceNodeId: string;
-    targetNodeId: string;
-    startPoint: any;
-    endPoint: any;
-    text: {
-      x: number;
-      y: number;
-      value: string;
-    };
-    properties: {};
-    zIndex?: number;
-    pointsList?: Point[]; // Folding lines and curves will output pointsList.
-  }[];
-};
-```
-
-Example：
-
-```jsx | pure
-lf.getGraphData();
-```
-
-## getGraphRawData
-
-Get the raw data of the flow graph. The difference with getGraphData is that the data obtained by this method is not affected by the adapter.
-
-```jsx | pure
-getGraphRawData(): GraphConfigData
-```
-
-Example：
-
-```jsx | pure
-lf.getGraphRawData();
-```
-
-## setProperties
-
-Set custom properties of nodes or edges
-
-```jsx | pure
-setProperties(id: string, properties: Object): void
-```
-
-Example：
-
-```jsx | pure
-lf.setProperties("aF2Md2P23moN2gasd", {
-  isRollbackNode: true,
+// get all the mods of the edges whose starting point is node A
+lf.getEdgeModels({
+  sourceNodeId: "nodeA_id",
+});
+// get all the mods of the edges whose ending point is node B
+lf.getEdgeModels({
+  targetNodeId: "nodeB_id",
+});
+// Get the edge whose starting point is node A and ending point is node B
+lf.getEdgeModels({
+  sourceNodeId: "nodeA_id",
+  targetNodeId: "nodeB_id",
 });
 ```
 
-## deleteProperty
+### changeEdgeId
 
-Delete node attributes
-
-```jsx | pure
-deleteProperty(id: string, key: string): void
-```
+Modify the edge id. If a new id is not passed, one will be created internally automatically.
 
 Example：
 
 ```jsx | pure
-lf.deleteProperty("aF2Md2P23moN2gasd", "isRollbackNode");
+lf.changeEdgeId("oldId", "newId");
 ```
 
-## getProperties
+### changeEdgeType
 
-Get the custom properties of a node or an edge
-
-```jsx | pure
-getProperties(id: string): Object
-```
+Switch type of the edge.
 
 Example：
 
 ```jsx | pure
-lf.getProperties("id");
+lf.changeEdgeType("edgeId", "bezier");
 ```
 
-## updateAttributes
+### deleteEdge
 
-Modifies an attribute in the corresponding element model, which is called [graphModel](graph-model-api#updateattributes) inside the method.
-
-:::warning
-This method is used with caution unless you know enough about logicflow internals.<br>
-In most cases, please use setProperties, updateText, changeNodeId, and so on.<br>
-For example, if you use this method to change the id of a Node, the sourceNodeId of the Edge connected to the Node will not be found.
-:::
-```jsx | pure
-updateAttributes(id: string, attributes: object): void
-```
-Example：
+Delete an edge based on its id.
 
 ```jsx | pure
-lf.updateAttributes("node_id_1", { radius: 4 });
+deleteEdge(id): void
 ```
-
-## toFront
-
-Places an element to the top.
-
-If the stacking mode is the default, the original top element is restored to its original level.
-
-If the stacking mode is incremental, the zIndex of the element to be specified is set to the current maximum zIndex + 1.
-
-Example：
-
-```jsx | pure
-lf.toFront("id");
-```
-
-## setElementZIndex
-
-Set the zIndex of the element.
-
-Note: This method is not recommended for the default stacking mode.
 
 Parameters:
 
-| Name | Type | Mandatory | Default | Description |
-| :----- | :-------------- | :--- | :----- | :---|
-| id     | String          | ✅   | - |  Node or edge id          |
-| zIndex | String\| Number | ✅       | -       | Passing numbers, also supports passing `top` and `bottom` |
+| Name       | Type   | Required | Default | Description        |
+| :--- | :----- | :--- | :----- | :------ |
+| id   | String |      | -      | Edge id |
 
 Example：
 
 ```jsx | pure
-lf.setElementZIndex("element_id", "top");
-lf.setElementZIndex("element_id", "bottom");
-lf.setElementZIndex("element_id", 2000);
+lf.deleteEdge("edge_1");
 ```
 
-## addElements
+### deleteEdgeByNodeId
 
-Batch add nodes and edges
+Deletes an edge of the specified type, based on the start and end points of the edge, and can pass only one of them.
+
+```jsx | pure
+deleteEdgeByNodeId(config: EdgeFilter): void
+```
+
+Parameters:
+
+| Name       | Type   | Required | Default | Description           |
+| :----------- | :----- | :--- | :----- | :-------------- |
+| sourceNodeId | String |          | -       | id of the starting node of the edge |
+| targetNodeId | String |          | -       | id of the ending node of the edge   |
+
+Example：
+
+```jsx | pure
+
+lf.deleteEdgeByNodeId({
+  sourceNodeId: "id1",
+  targetNodeId: "id2",
+});
+
+lf.deleteEdgeByNodeId({
+  sourceNodeId: "id1",
+});
+
+lf.deleteEdgeByNodeId({
+  targetNodeId: "id2",
+});
+```
+
+### getNodeEdges
+
+Get the model of all edges connected by the node.
+
+```jsx | pure
+getNodeEdges(id: string): BaseEdgeModel[]
+```
+
+| Parameter | Type   | Required | Default | Description |
+| :-------- | :----- | :------- | :------ | :---------- |
+| id        | String | ✅       |         | Node id     |
+
+Example：
+
+```jsx | pure
+const edgeModels = lf.getNodeEdges("node_id");
+```
+
+## Element Related
+
+### addElements
+
+Batch add nodes and edges.
 
 Example：
 
@@ -778,7 +539,106 @@ lf.addElements({
 });
 ```
 
-## getAreaElement
+### selectElementById
+
+Select the graph.
+
+Parameters:
+
+| Name       | Type   | Required | Default | Description                                                  |
+| :------- | :------ | :--- | :----- | :----------------------- |
+| id       | string  | ✅   | -      | Node or edge id                                    |
+| multiple | boolean |      | false  | If or not is multi-selected, if true, the last selected element will not be reset. |
+| toFront  | boolean |      | true   | If or not the selected element will be topped, default is true.   |
+
+Example：
+
+```jsx | pure
+lf.selectElementById(id: string, multiple = false, toFront = true)
+```
+
+### getSelectElements
+
+Get all elements selected.
+
+```jsx | pure
+getSelectElements(isIgnoreCheck: boolean): GraphConfigData
+```
+
+| Name          | Type    | Required | Default | Description         |
+| :------------ | :------ | :--- | :----- | :----------------------------------------------------------- |
+| isIgnoreCheck | boolean | ✅   | true   |  Whether to include edges where sourceNode and targetNode are not selected, default is include. |
+
+```jsx | pure
+lf.getSelectElements(false);
+```
+
+### clearSelectElements
+
+Uncheck all elements.
+
+```jsx | pure
+lf.clearSelectElements();
+```
+
+### getModelById
+
+Get the `model` of a node or edge based on its `id`.
+
+```jsx | pure
+lf.getModelById("node_id");
+lf.getModelById("edge_id");
+```
+
+### getDataById
+
+Get the `data` of a node or edge based on its `id`.
+
+```jsx | pure
+lf.getDataById("node_id");
+lf.getDataById("edge_id");
+```
+
+### deleteElement
+
+Delete the element by id.
+
+```jsx | pure
+deleteElement(id: string): boolean
+```
+
+| Name       | Type   | Required | Default | Description              |
+| :--- | :----- | :--- | :----- | :------------ |
+| id   | String | ✅   |        | Node or Edge id |
+
+Example：
+
+```jsx | pure
+lf.deleteElement("node_id");
+```
+
+### setElementZIndex
+
+Set the zIndex of the element.
+
+Note: This method is not recommended for the default stacking mode.
+
+Parameters:
+
+| Name | Type | Mandatory | Default | Description |
+| :----- | :-------------- | :--- | :----- | :---|
+| id     | String          | ✅   | - |  Node or edge id          |
+| zIndex | String\| Number | ✅       | -       | Passing numbers, also supports passing `top` and `bottom` |
+
+Example：
+
+```jsx | pure
+lf.setElementZIndex("element_id", "top");
+lf.setElementZIndex("element_id", "bottom");
+lf.setElementZIndex("element_id", 2000);
+```
+
+### getAreaElement
 
 Gets all the elements in the specified region, which must be a DOM layer.
 
@@ -798,57 +658,93 @@ Parameters:
 lf.getAreaElement([100, 100], [500, 500]);
 ```
 
-## getSelectElements
+### setProperties
 
-Get all elements selected
-
-```jsx | pure
-getSelectElements(isIgnoreCheck: boolean): GraphConfigData
-```
-
-| Name          | Type    | Required | Default | Description         |
-| :------------ | :------ | :--- | :----- | :----------------------------------------------------------- |
-| isIgnoreCheck | boolean | ✅   | true   |  Whether to include edges where sourceNode and targetNode are not selected, default is include. |
+Set the custom properties of nodes or edges.
 
 ```jsx | pure
-lf.getSelectElements(false);
+setProperties(id: string, properties: Object): void
 ```
 
-## clearSelectElements
-
-Uncheck all elements
+Example：
 
 ```jsx | pure
-lf.clearSelectElements();
+lf.setProperties("aF2Md2P23moN2gasd", {
+  isRollbackNode: true,
+});
 ```
 
-## getModelById
+### getProperties
 
-Get the model of a node or edge based on its id
+Get the custom properties of a node or an edge.
 
 ```jsx | pure
-lf.getModelById("node_id");
-lf.getModelById("edge_id");
+getProperties(id: string): Object
 ```
 
-## getDataById
-
-Get data of a node or edge based on its id
+Example：
 
 ```jsx | pure
-lf.getDataById("node_id");
-lf.getDataById("edge_id");
+lf.getProperties("id");
 ```
 
-## clearData
+### deleteProperty
 
-Clear the canvas
+Delete node attributes.
 
 ```jsx | pure
-lf.clearData();
+deleteProperty(id: string, key: string): void
 ```
 
-## updateEditConfig
+Example：
+
+```jsx | pure
+lf.deleteProperty("aF2Md2P23moN2gasd", "isRollbackNode");
+```
+
+### updateAttributes
+
+Modifies an attribute in the corresponding element model, which is called [graphModel](graph-model-api#updateattributes) inside the method.
+
+:::warning
+This method is used with caution unless you know enough about logicflow internals.<br>
+In most cases, please use setProperties, updateText, changeNodeId, and so on.<br>
+For example, if you use this method to change the id of a Node, the sourceNodeId of the Edge connected to the Node will not be found.
+:::
+```jsx | pure
+updateAttributes(id: string, attributes: object): void
+```
+Example：
+
+```jsx | pure
+lf.updateAttributes("node_id_1", { radius: 4 });
+```
+## Text Related
+
+### editText
+
+same as [graphModel.editText](graph-model-api#edittext)
+
+### updateText
+
+Update the node or edge text.
+
+```jsx | pure
+updateText(id: string, value: string): void
+```
+
+| Name       | Type   | Required | Default | Description              |
+| :---- | :----- | :--- | :----- | :------------- |
+| id    | String | ✅   |        | Node or Edge id  |
+| value | String | ✅   |        | Updated text values |
+
+Example：
+
+```jsx | pure
+lf.updateText("id", "value");
+```
+
+### updateEditConfig
 
 Update the basic configuration of the flow editor.
 
@@ -860,7 +756,7 @@ lf.updateEditConfig({
 });
 ```
 
-## getEditConfig
+### getEditConfig
 
 Get the basic configuration of the flow editor.
 
@@ -870,9 +766,70 @@ See [editConfig](edit-config-model-api) for detailed parameters
 lf.getEditConfig();
 ```
 
-## getPointByClient
+## Graph Related
 
-Get the coordinates of the event location relative to the top left corner of the canvas
+### setTheme
+
+Set the theme, see [Theme](theme-api) for details.
+
+### focusOn
+
+Position to the center of the canvas viewport.
+
+Parameters:
+
+| Name        | Type   | Required | Default | Description       |
+| :---------- | :----- | :--- | :----- | :----------- |
+| focusOnArgs | object | ✅   | -      | Required parameters for positioning |
+
+Example：
+
+```jsx | pure
+//  position the center of the canvas viewport to the position of the node_1 element
+lf.focusOn({
+  id: "node_1",
+});
+// position the center of the canvas viewport to the coordinates [1000, 1000]
+lf.focusOn({
+  coordinate: {
+    x: 1000,
+    y: 1000,
+  },
+});
+```
+
+### resize
+
+Adjusts the width and height of the canvas, if the width or height is not passed, the width and height of the canvas will be calculated automatically.
+
+Parameters:
+
+| Name | Type | Mandatory | Default | Description     |
+| :----- | :----- | :--- | :----- | :------- |
+| width  | Number |      | -      | Width of the canvas  |
+| height | Number | ✅   | -      | Height of the canvas |
+
+```jsx | pure
+lf.resize(1200, 600);
+```
+
+### toFront
+
+Places an element to the top.
+
+If the stacking mode is the default, the original top element is restored to its original level.
+
+If the stacking mode is incremental, the zIndex of the element to be specified is set to the current maximum zIndex + 1.
+
+Example：
+
+```jsx | pure
+lf.toFront("id");
+```
+
+### getPointByClient
+
+Get the coordinates of the event location relative to the top left corner of the canvas.
 
 The location of the canvas can be anywhere on the page. The coordinates returned by the native event are relative to the top-left corner of the page, and this method provides the exact location with the top-left corner of the canvas as the origin.
 
@@ -910,50 +867,130 @@ Example：
 lf.getPointByClient(event.x, event.y);
 ```
 
-## focusOn
+### getGraphData
 
-Position to the center of the canvas viewport
+Get flow graphing data.
 
-Parameters:
+```jsx | pure
+// Return value. If the adapter plugin is applied and the setting is adapterOut, the return is the converted data format, otherwise it is the default format.
+// Starting from version 1.2.5, new input parameters have been added for the execution of certain adapterOut that require input parameters.
+// For example, the built-in BpmnAdapter may require an array of attribute reserve fields to be passed in to ensure that certain node attributes in the exported data are properly processed.
+// The input parameters here should be consistent with the other parameters of the adapterOut method from the imported adapter, except for the data parameter.
+getGraphData(...params: any): GraphConfigData | unknown
+```
 
-| Name        | Type   | Required | Default | Description       |
-| :---------- | :----- | :--- | :----- | :----------- |
-| focusOnArgs | object | ✅   | -      | Required parameters for positioning |
+LogicFlow default data format.
+
+```jsx | pure
+type GraphConfigData = {
+  nodes: {
+    id?: string;
+    type: string;
+    x: number;
+    y: number;
+    text?: TextConfig;
+    properties?: Record<string, unknown>;
+    zIndex?: number;
+  }[];
+  edges: {
+    id: string;
+    type: string;
+    sourceNodeId: string;
+    targetNodeId: string;
+    startPoint: any;
+    endPoint: any;
+    text: {
+      x: number;
+      y: number;
+      value: string;
+    };
+    properties: {};
+    zIndex?: number;
+    pointsList?: Point[]; // Folding lines and curves will output pointsList.
+  }[];
+};
+```
 
 Example：
 
 ```jsx | pure
-//  position the center of the canvas viewport to the position of the node_1 element
-lf.focusOn({
-  id: "node_1",
-});
-// position the center of the canvas viewport to the coordinates [1000, 1000]
-lf.focusOn({
-  coordinate: {
-    x: 1000,
-    y: 1000,
-  },
-});
+lf.getGraphData();
 ```
 
-## resize
+### getGraphRawData
 
-Adjusts the width and height of the canvas, if the width or height is not passed, the width and height of the canvas will be calculated automatically.
-
-Parameters:
-
-| Name | Type | Mandatory | Default | Description     |
-| :----- | :----- | :--- | :----- | :------- |
-| width  | Number |      | -      | Width of the canvas  |
-| height | Number | ✅   | -      | Height of the canvas |
+Get the raw data of the flow graph. The difference with getGraphData is that the data obtained by this method is not affected by the adapter.
 
 ```jsx | pure
-lf.resize(1200, 600);
+getGraphRawData(): GraphConfigData
 ```
 
-## zoom
+Example：
 
-Zoom in and out of the canvas
+```jsx | pure
+lf.getGraphRawData();
+```
+
+### clearData
+
+Clear the canvas.
+
+```jsx | pure
+lf.clearData();
+```
+
+### renderRawData
+
+Rendering of the raw graph data. The difference with `render` is that after using `adapter`, you can use this method if you still want to render the data in logicflow format.
+
+```jsx | pure
+const lf = new LogicFlow({
+  ...
+})
+lf.renderRawData({
+  nodes: [],
+  edges: []
+})
+```
+
+### render
+
+Render graph data.
+
+```jsx | pure
+const lf = new LogicFlow({
+  ...
+})
+lf.render(graphData)
+```
+
+## History Related
+
+### undo
+
+History Operation - Back to previous step.
+
+Example：
+
+```jsx | pure
+lf.undo();
+```
+
+### redo
+
+History Operation - Resume next.
+
+Example：
+
+```jsx | pure
+lf.redo();
+```
+
+## Resize Related
+
+### zoom
+
+Zoom in or out of the canvas.
 
 Parameters:
 
@@ -975,9 +1012,9 @@ lf.zoom(2);
 lf.zoom(2, [100, 100]);
 ```
 
-## resetZoom
+### resetZoom
 
-Resets the zoom scale of the graph to default
+Reset the zoom ratio of the drawing to the default, which is 1.
 
 Example：
 
@@ -985,7 +1022,7 @@ Example：
 lf.resetZoom();
 ```
 
-## setZoomMiniSize
+### setZoomMiniSize
 
 Sets the minimum number of times the graph can be scaled when it is reduced. The parameter takes values from 0 to 1. Default 0.2
 
@@ -1005,9 +1042,9 @@ Example：
 lf.setZoomMiniSize(0.3);
 ```
 
-## setZoomMaxSize
+### setZoomMaxSize
 
-Set the maximum magnification
+Set the maximum zoom scale when zooming in; default is 16.
 
 ```jsx | pure
 setZoomMaxSize(size: number): void
@@ -1025,18 +1062,18 @@ Example：
 lf.setZoomMaxSize(20);
 ```
 
-## getTransform
+### getTransform
 
-Get the zoom in/out value of the current canvas
+Get the zoom in/out value of the current canvas.
 
 ```jsx | pure
 const transform = lf.getTransform();
 console.log(transform);
 ```
 
-## translate
+### translate
 
-Panning graph
+Panning graph.
 
 Parameters
 
@@ -1049,25 +1086,25 @@ Parameters
 lf.translate(100, 100);
 ```
 
-## translateCenter
+### resetTranslate
 
-Graphics canvas centering
-
-```jsx | pure
-lf.translateCenter();
-```
-
-## resetTranslate
-
-Restore the graph to its original position
+Restore the graph to its original position.
 
 ```jsx | pure
 lf.resetTranslate();
 ```
 
-## fitView
+### translateCenter
 
-Reduce the entire flowchart to a size where the entire canvas can be displayed
+Graphics canvas centering.
+
+```jsx | pure
+lf.translateCenter();
+```
+
+### fitView
+
+Reduce the entire flowchart to a size where the entire canvas can be displayed.
 
 Parameters:
 
@@ -1080,21 +1117,27 @@ Parameters:
 lf.fitView(deltaX, deltaY);
 ```
 
-## openEdgeAnimation
+### openEdgeAnimation
+
+Enable edge animations.
 
 ```jsx | pure
 lf.openEdgeAnimation(edgeId: string):void;
 ```
 
-## closeEdgeAnimation
+### closeEdgeAnimation
+
+Disable edge animations.
 
 ```jsx | pure
 lf.closeEdgeAnimation(edgeId: string):void;
 ```
 
-## on
+## Event System Related
 
-Listening events of the graph，see [event](event-center-api)
+### on
+
+Event listener for the graph, see [event](event-center-api).
 
 ```jsx | pure
 on(evt: string, callback: Function): this
@@ -1125,9 +1168,9 @@ lf.on("element:click", (args) => {
 });
 ```
 
-## off
+### off
 
-Remove event listener
+Remove event listener.
 
 ```jsx | pure
 off(evt: string, callback: Function): this
@@ -1151,9 +1194,9 @@ lf.off("element:click", () => {
 });
 ```
 
-## once
+### once
 
-Event Listening Once
+Event listener that triggers only once.
 
 ```jsx | pure
 once(evt: string, callback: Function): this
@@ -1174,9 +1217,9 @@ lf.once("node:click", () => {
 });
 ```
 
-## emit
+### emit
 
-Trigger events
+Trigger an event.
 
 ```jsx | pure
 emit(evt: string, ...args): this
@@ -1193,24 +1236,4 @@ Example：
 
 ```jsx | pure
 lf.emit("custom:button-click", model);
-```
-
-## undo
-
-History Operation - Back to previous step
-
-Example：
-
-```jsx | pure
-lf.undo();
-```
-
-## redo
-
-History Operation - Resume Next
-
-Example：
-
-```jsx | pure
-lf.redo();
 ```

--- a/sites/docs/docs/api/detail/index.md
+++ b/sites/docs/docs/api/detail/index.md
@@ -5,17 +5,19 @@ table td:first-of-type {
 }
 </style>
 
-## register
+## Register 相关
 
-注册节点、边
+### register
+
+注册自定义节点、边。
 
 ```jsx | pure
-lf.register(config):void
+lf.register(config: RegisterConfig):void
 ```
 
 参数：
 
-| 参数名       | 类型   | 必传 | 默认值 | 描述          |
+| 名称       | 类型   | 必传 | 默认值 | 描述          |
 | :----------- | :----- | :--- | :----- | :------------------- |
 | config.type  | String | ✅   | -      | 自定义节点、边的名称 |
 | config.model | Model  | ✅   | -      | 节点、边的 model     |
@@ -24,29 +26,27 @@ lf.register(config):void
 示例：
 
 ```jsx | pure
-import { RectNode, RectNodeModel, h } from "@logicflow/core";
+import { RectNode, RectNodeModel } from "@logicflow/core";
 // 节点View
-class UserNode extends RectNode {}
+class CustomRectNode extends RectNode {}
 // 节点Model
-class UserModel extends RectNodeModel {
-  constructor(data) {
-    super(data);
-    const { size } = data.properties;
-    this.width = size * 40;
-    this.height = size * 40;
-    this.fill = "green";
+class CustomRectModel extends RectNodeModel {
+  setAttributes() {
+    this.width = 200;
+    this.height = 80;
+    this.radius = 50;
   }
 }
 lf.register({
-  type: "user",
-  view: UserNode,
-  model: UserModel,
+  type: "Custom-rect",
+  view: CustomRectNode,
+  model: CustomRectModel,
 });
 ```
 
-## batchRegister
+### batchRegister
 
-批量注册
+批量注册。
 
 ```jsx | pure
 lf.batchRegister([
@@ -63,73 +63,9 @@ lf.batchRegister([
 );
 ```
 
-## render
+## Node 相关
 
-渲染图数据
-
-```jsx | pure
-const lf = new LogicFlow({
-  ...
-})
-lf.render(graphData)
-```
-
-## renderRawData
-
-渲染图原始数据，和`render`的区别是在使用`adapter`后，如何还想渲染 logicflow 格式的数据，可以用此方法。
-
-```jsx | pure
-const lf = new LogicFlow({
-  ...
-})
-lf.renderRawData({
-  nodes: [],
-  edges: []
-})
-```
-
-## setTheme
-
-设置主题, 详情见[主题](theme-api)
-
-## changeNodeType
-
-修改节点类型
-
-```jsx | pure
-changeNodeType(id: string, type: string): void
-```
-
-| 名称 | 类型   | 必传 | 默认值 | 描述     |
-| :--- | :----- | :--- | :----- | :------- |
-| id   | String | ✅   |        | 节点 id  |
-| type | String | ✅   |        | 新的类型 |
-
-示例：
-
-```jsx | pure
-lf.changeNodeType("node_id", "rect");
-```
-
-## getNodeEdges
-
-获取节点连接的所有边的 model
-
-```jsx | pure
-getNodeEdges(id: string): BaseEdgeModel[]
-```
-
-| 名称 | 类型   | 必传 | 默认值 | 描述    |
-| :--- | :----- | :--- | :----- | :------ |
-| id   | String | ✅   |        | 节点 id |
-
-示例：
-
-```jsx | pure
-const edgeModels = lf.getNodeEdges("node_id");
-```
-
-## addNode
+### addNode
 
 在图上添加节点。
 
@@ -167,7 +103,7 @@ lf.addNode({
 });
 ```
 
-## deleteNode
+### deleteNode
 
 删除图上的节点, 如果这个节点上有连接线，则同时删除线。
 
@@ -187,9 +123,9 @@ deleteNode(nodeId: string): void
 lf.deleteNode("id");
 ```
 
-## cloneNode
+### cloneNode
 
-克隆节点
+克隆节点。
 
 ```jsx | pure
 cloneNode(nodeId: string): BaseNodeModel
@@ -207,7 +143,7 @@ cloneNode(nodeId: string): BaseNodeModel
 lf.cloneNode("id");
 ```
 
-## changeNodeId
+### changeNodeId
 
 修改节点的 id， 如果不传新的 id，会内部自动创建一个。
 
@@ -217,9 +153,28 @@ lf.cloneNode("id");
 lf.changeNodeId("oldId", "newId");
 ```
 
-## getNodeModelById
+### changeNodeType
 
-获取节点的`model`
+修改节点类型。
+
+```jsx | pure
+changeNodeType(id: string, type: string): void
+```
+
+| 名称 | 类型   | 必传 | 默认值 | 描述     |
+| :--- | :----- | :--- | :----- | :------- |
+| id   | String | ✅   |        | 节点 id  |
+| type | String | ✅   |        | 新的类型 |
+
+示例：
+
+```jsx | pure
+lf.changeNodeType("node_id", "rect");
+```
+
+### getNodeModelById
+
+获取节点的`model`。
 
 ```jsx | pure
 getNodeModelById(nodeId: string): BaseNodeModel
@@ -237,9 +192,9 @@ getNodeModelById(nodeId: string): BaseNodeModel
 lf.getNodeModelById("id");
 ```
 
-## getNodeDataById
+### getNodeDataById
 
-获取节点的`model`数据
+获取节点的`model`数据。
 
 ```jsx | pure
 getNodeDataById(nodeId: string): NodeConfig
@@ -257,37 +212,9 @@ getNodeDataById(nodeId: string): NodeConfig
 lf.getNodeDataById("id");
 ```
 
-## getNodeIncomingNode
+### getNodeIncomingEdge
 
-获取节点所有的上一级节点
-
-```jsx | pure
-getNodeIncomingNode(nodeId: string): BaseNodeModel[]
-```
-
-参数：
-
-| 名称   | 类型   | 必传 | 默认值 | 描述    |
-| :----- | :----- | :--- | :----- | :------ |
-| nodeId | String | ✅   | -      | 节点 id |
-
-## getNodeOutgoingNode
-
-获取节点所有的下一级节点
-
-```jsx | pure
-getNodeOutgoingNode(nodeId: string): BaseNodeModel[]
-```
-
-参数：
-
-| 名称   | 类型   | 必传 | 默认值 | 描述    |
-| :----- | :----- | :--- | :----- | :------ |
-| nodeId | String | ✅   | -      | 节点 id |
-
-## getNodeIncomingEdge
-
-获取所有以此节点为终点的边
+获取所有以此节点为终点的边。
 
 ```jsx | pure
 getNodeIncomingEdge(nodeId: string): BaseEdgeModel[]
@@ -299,9 +226,9 @@ getNodeIncomingEdge(nodeId: string): BaseEdgeModel[]
 | :----- | :----- | :--- | :----- | :------ |
 | nodeId | String | ✅   | -      | 节点 id |
 
-## getNodeOutgoingEdge
+### getNodeOutgoingEdge
 
-获取所有以此节点为起点的边
+获取所有以此节点为起点的边。
 
 ```jsx | pure
 getNodeOutgoingEdge(nodeId: string): BaseEdgeModel[]
@@ -313,9 +240,57 @@ getNodeOutgoingEdge(nodeId: string): BaseEdgeModel[]
 | :----- | :----- | :--- | :----- | :------ |
 | nodeId | String | ✅   | -      | 节点 id |
 
-## addEdge
+### getNodeIncomingNode
 
-创建连接两个节点的边
+获取节点所有的上一级节点。
+
+```jsx | pure
+getNodeIncomingNode(nodeId: string): BaseNodeModel[]
+```
+
+参数：
+
+| 名称   | 类型   | 必传 | 默认值 | 描述    |
+| :----- | :----- | :--- | :----- | :------ |
+| nodeId | String | ✅   | -      | 节点 id |
+
+### getNodeOutgoingNode
+
+获取节点所有的下一级节点。
+
+```jsx | pure
+getNodeOutgoingNode(nodeId: string): BaseNodeModel[]
+```
+
+参数：
+
+| 名称   | 类型   | 必传 | 默认值 | 描述    |
+| :----- | :----- | :--- | :----- | :------ |
+| nodeId | String | ✅   | -      | 节点 id |
+
+## Edge 相关
+
+### setDefaultEdgeType
+
+设置边的类型, 也就是设置在节点直接由用户手动绘制的连线类型。
+
+```jsx | pure
+setDefaultEdgeType(type: EdgeType): void
+```
+
+| 名称 | 类型   | 必传 | 默认值     | 描述                                                                                                                                    |
+| :--- | :----- | :--- | :--------- | :-------------------------------------------------------------------------------------------------------------------------------------- |
+| type | String | ✅   | 'polyline' | 设置边的类型，内置支持的边类型有 line(直线)、polyline(折线)、bezier(贝塞尔曲线)，默认为折线，用户可以自定义 type 名切换到用户自定义的边 |
+
+示例：
+
+```jsx | pure
+lf.setDefaultEdgeType("line");
+```
+
+### addEdge
+
+创建连接两个节点的边。
 
 ```jsx | pure
 addEdge(edgeConfig: EdgeConifg): void
@@ -351,126 +326,9 @@ lf.addEdge({
 });
 ```
 
-## deleteEdge
+### getEdgeDataById
 
-基于边 id 删除边
-
-```jsx | pure
-deleteEdge(id): void
-```
-
-参数：
-
-| 名称 | 类型   | 必传 | 默认值 | 描述    |
-| :--- | :----- | :--- | :----- | :------ |
-| id   | String |      | -      | 边的 id |
-
-示例：
-
-```jsx | pure
-lf.deleteEdge("edge_1");
-```
-
-## deleteEdgeByNodeId
-
-删除与指定节点相连的边, 基于边起点和终点。
-
-```jsx | pure
-deleteEdgeByNodeId(config: EdgeFilter): void
-```
-
-参数：
-
-| 名称         | 类型   | 必传 | 默认值 | 描述            |
-| :----------- | :----- | :--- | :----- | :-------------- |
-| sourceNodeId | String |      | -      | 边起始节点的 id |
-| targetNodeId | String |      | -      | 边终止节点的 id |
-
-示例：
-
-```jsx | pure
-// 删除起点id为id1并且终点id为id2的边
-lf.deleteEdgeByNodeId({
-  sourceNodeId: "id1",
-  targetNodeId: "id2",
-});
-// 删除起点id为id1的边
-lf.deleteEdgeByNodeId({
-  sourceNodeId: "id1",
-});
-// 删除终点id为id2的边
-lf.deleteEdgeByNodeId({
-  targetNodeId: "id2",
-});
-```
-
-## getEdgeModelById
-
-基于边 Id 获取边的`model`
-
-```jsx | pure
-getEdgeModelById(edgeId: string): BaseEdgeModel
-```
-
-参数：
-
-| 名称   | 类型   | 必传 | 默认值 | 描述    |
-| :----- | :----- | :--- | :----- | :------ |
-| edgeId | String | ✅   | -      | 节点 id |
-
-示例：
-
-```jsx | pure
-lf.getEdgeModelById("id");
-```
-
-## getEdgeModels
-
-获取满足条件边的 model
-
-| 名称       | 类型   | 必传 | 默认值 | 描述     |
-| :--------- | :----- | :--- | :----- | :------- |
-| edgeFilter | Object | ✅   | -      | 过滤条件 |
-
-```jsx | pure
-// 获取所有起点为节点A的边的model
-lf.getEdgeModels({
-  sourceNodeId: "nodeA_id",
-});
-// 获取所有终点为节点B的边的model
-lf.getEdgeModels({
-  targetNodeId: "nodeB_id",
-});
-// 获取起点为节点A，终点为节点B的边
-lf.getEdgeModels({
-  sourceNodeId: "nodeA_id",
-  targetNodeId: "nodeB_id",
-});
-```
-
-## changeEdgeId
-
-修改边的 id， 如果不传新的 id，会内部自动创建一个。
-
-示例：
-
-```jsx | pure
-lf.changeEdgeId("oldId", "newId");
-```
-
-## changeEdgeType
-
-切换边的类型
-
-示例：
-
-```jsx | pure
-lf.changeEdgeType("edgeId", "bezier");
-```
-
-## getEdgeDataById
-
-通过`id`获取边的数据
+通过`id`获取边的数据。
 
 ```jsx | pure
 getEdgeDataById(edgeId: string): EdgeConfig
@@ -510,248 +368,146 @@ export type EdgeConfig = {
 lf.getEdgeDataById("id");
 ```
 
-## setDefaultEdgeType
+### getEdgeModelById
 
-设置边的类型, 也就是设置在节点直接由用户手动绘制的连线类型。
-
-```jsx | pure
-setDefaultEdgeType(type: EdgeType): void
-```
-
-| 名称 | 类型   | 必传 | 默认值     | 描述                                                                                                                                    |
-| :--- | :----- | :--- | :--------- | :-------------------------------------------------------------------------------------------------------------------------------------- |
-| type | String | ✅   | 'polyline' | 设置边的类型，内置支持的边类型有 line(直线)、polyline(折线)、bezier(贝塞尔曲线)，默认为折线，用户可以自定义 type 名切换到用户自定义的边 |
-
-示例：
+基于边 Id 获取边的`model`。
 
 ```jsx | pure
-lf.setDefaultEdgeType("line");
+getEdgeModelById(edgeId: string): BaseEdgeModel
 ```
-
-## editText
-
-同[graphModel.editText](graph-model-api#edittext)
-
-## updateText
-
-更新节点或者边的文案
-
-```jsx | pure
-updateText(id: string, value: string): void
-```
-
-| 名称  | 类型   | 必传 | 默认值 | 描述           |
-| :---- | :----- | :--- | :----- | :------------- |
-| id    | String | ✅   |        | 节点或者边 id  |
-| value | String | ✅   |        | 更新后的文本值 |
-
-示例：
-
-```jsx | pure
-lf.updateText("id", "value");
-```
-
-## deleteElement
-
-删除元素
-
-```jsx | pure
-deleteElement(id: string): boolean
-```
-
-| 名称 | 类型   | 必传 | 默认值 | 描述          |
-| :--- | :----- | :--- | :----- | :------------ |
-| id   | String | ✅   |        | 节点或者边 id |
-
-示例：
-
-```jsx | pure
-lf.deleteElement("node_id");
-```
-
-## selectElementById
-
-将图形选中
 
 参数：
 
-| 参数名   | 类型    | 必传 | 默认值 | 描述                                                |
-| :------- | :------ | :--- | :----- | :-------------------------------------------------- |
-| id       | string  | ✅   | -      | 节点或者连线 Id                                     |
-| multiple | boolean |      | false  | 是否为多选，如果为 true，不会将上一个选中的元素重置 |
-| toFront  | boolean |      | true   | 是否将选中的元素置顶，默认为 true                   |
+| 名称   | 类型   | 必传 | 默认值 | 描述    |
+| :----- | :----- | :--- | :----- | :------ |
+| edgeId | String | ✅   | -      | 节点 id |
 
 示例：
 
 ```jsx | pure
-lf.selectElementById(id: string, multiple = false, toFront = true)
+lf.getEdgeModelById("id");
 ```
 
-## getGraphData
+### getEdgeModels
 
-获取流程绘图数据
+获取满足条件边的 model。
 
-```jsx | pure
-// 返回值，如果是应用了adapter插件，且设置为adapterOut，返回为转换后的数据格式，否则为默认的格式
-// 1.2.5版本以后新增了入参，用于某些需要入参的adapterOut的执行，例如内置的BpmnAdapter可能需要传入属性保留字段的数组来保证导出数据中的某些节点属性被正常处理。
-// 这里的入参和引入的Adapter的adapterOut方法除了data以外的其他参数保持一致。
-getGraphData(...params: any): GraphConfigData | unknown
-```
-
-LogicFlow 默认数据格式
+| 名称       | 类型   | 必传 | 默认值 | 描述     |
+| :--------- | :----- | :--- | :----- | :------- |
+| edgeFilter | Object | ✅   | -      | 过滤条件 |
 
 ```jsx | pure
-type GraphConfigData = {
-  nodes: {
-    id?: string;
-    type: string;
-    x: number;
-    y: number;
-    text?: TextConfig;
-    properties?: Record<string, unknown>;
-    zIndex?: number;
-  }[];
-  edges: {
-    id: string;
-    type: string;
-    sourceNodeId: string;
-    targetNodeId: string;
-    startPoint: any;
-    endPoint: any;
-    text: {
-      x: number;
-      y: number;
-      value: string;
-    };
-    properties: {};
-    zIndex?: number;
-    pointsList?: Point[]; // 折线、曲线会输出pointsList
-  }[];
-};
-```
-
-示例：
-
-```jsx | pure
-lf.getGraphData();
-```
-
-## getGraphRawData
-
-获取流程绘图原始数据， 与 getGraphData 区别是该方法获取的数据不会受到 adapter 影响。
-
-```jsx | pure
-getGraphRawData(): GraphConfigData
-```
-
-示例：
-
-```jsx | pure
-lf.getGraphRawData();
-```
-
-## setProperties
-
-设置节点或者边的自定义属性
-
-```jsx | pure
-setProperties(id: string, properties: Object): void
-```
-
-示例：
-
-```jsx | pure
-lf.setProperties("aF2Md2P23moN2gasd", {
-  isRollbackNode: true,
+// 获取所有起点为节点A的边的model
+lf.getEdgeModels({
+  sourceNodeId: "nodeA_id",
+});
+// 获取所有终点为节点B的边的model
+lf.getEdgeModels({
+  targetNodeId: "nodeB_id",
+});
+// 获取起点为节点A，终点为节点B的边
+lf.getEdgeModels({
+  sourceNodeId: "nodeA_id",
+  targetNodeId: "nodeB_id",
 });
 ```
 
-## deleteProperty
+### changeEdgeId
 
-删除节点属性
-
-```jsx | pure
-deleteProperty(id: string, key: string): void
-```
+修改边的 id， 如果不传新的 id，会内部自动创建一个。
 
 示例：
 
 ```jsx | pure
-lf.deleteProperty("aF2Md2P23moN2gasd", "isRollbackNode");
+lf.changeEdgeId("oldId", "newId");
 ```
 
-## getProperties
+### changeEdgeType
 
-获取节点或者边的自定义属性
-
-```jsx | pure
-getProperties(id: string): Object
-```
+切换边的类型。
 
 示例：
 
 ```jsx | pure
-lf.getProperties("id");
+lf.changeEdgeType("edgeId", "bezier");
 ```
 
-## updateAttributes
+### deleteEdge
 
-修改对应元素 model 中的属性, 方法内部就是调用的[graphModel](graph-model-api#updateattributes)
-
-:::warning{title=注意}
-此方法慎用，除非您对logicflow内部有足够的了解。<br>
-大多数情况下，请使用setProperties、updateText、changeNodeId等方法。<br>
-例如直接使用此方法修改节点的id,那么就是会导致连接到此节点的边的sourceNodeId出现找不到的情况。
-:::
-```jsx | pure
-updateAttributes(id: string, attributes: object): void
-```
-示例：
+基于边 id 删除边。
 
 ```jsx | pure
-lf.updateAttributes("node_id_1", { radius: 4 });
+deleteEdge(id): void
 ```
-
-## toFront
-
-将某个元素放置到顶部。
-
-如果堆叠模式为默认模式，则将指定元素置顶 zIndex 设置为 9999，原置顶元素重新恢复原有层级 zIndex 设置为 1。
-
-如果堆叠模式为递增模式，则将需指定元素 zIndex 设置为当前最大 zIndex + 1。
-
-示例：
-
-```jsx | pure
-lf.toFront("id");
-```
-
-## setElementZIndex
-
-设置元素的 zIndex.
-
-注意：默认堆叠模式下，不建议使用此方法。
 
 参数：
 
-| 名称   | 类型            | 必传 | 默认值 | 描述                                    |
-| :----- | :-------------- | :--- | :----- | :-------------------------------------- |
-| id     | String          | ✅   | -      | 边或者节点 id                           |
-| zIndex | String\| Number | ✅   | -      | 可以传数字，也支持传入`top` 和 `bottom` |
+| 名称 | 类型   | 必传 | 默认值 | 描述    |
+| :--- | :----- | :--- | :----- | :------ |
+| id   | String |      | -      | 边的 id |
 
 示例：
 
 ```jsx | pure
-// 置为顶部
-lf.setElementZIndex("element_id", "top");
-// 置为底部
-lf.setElementZIndex("element_id", "bottom");
-lf.setElementZIndex("element_id", 2000);
+lf.deleteEdge("edge_1");
 ```
 
-## addElements
+### deleteEdgeByNodeId
 
-批量添加节点和边
+删除与指定节点相连的边, 基于边起点和终点。
+
+```jsx | pure
+deleteEdgeByNodeId(config: EdgeFilter): void
+```
+
+参数：
+
+| 名称         | 类型   | 必传 | 默认值 | 描述            |
+| :----------- | :----- | :--- | :----- | :-------------- |
+| sourceNodeId | String |      | -      | 边起始节点的 id |
+| targetNodeId | String |      | -      | 边终止节点的 id |
+
+示例：
+
+```jsx | pure
+// 删除起点id为id1并且终点id为id2的边
+lf.deleteEdgeByNodeId({
+  sourceNodeId: "id1",
+  targetNodeId: "id2",
+});
+// 删除起点id为id1的边
+lf.deleteEdgeByNodeId({
+  sourceNodeId: "id1",
+});
+// 删除终点id为id2的边
+lf.deleteEdgeByNodeId({
+  targetNodeId: "id2",
+});
+```
+
+### getNodeEdges
+
+获取节点连接的所有边的 model。
+
+```jsx | pure
+getNodeEdges(id: string): BaseEdgeModel[]
+```
+
+| 名称 | 类型   | 必传 | 默认值 | 描述    |
+| :--- | :----- | :--- | :----- | :------ |
+| id   | String | ✅   |        | 节点 id |
+
+示例：
+
+```jsx | pure
+const edgeModels = lf.getNodeEdges("node_id");
+```
+
+## Element 相关
+
+### addElements
+
+批量添加节点和边。
 
 示例：
 
@@ -783,7 +539,108 @@ lf.addElements({
 });
 ```
 
-## getAreaElement
+### selectElementById
+
+将图形选中。
+
+参数：
+
+| 参数名   | 类型    | 必传 | 默认值 | 描述                                                |
+| :------- | :------ | :--- | :----- | :-------------------------------------------------- |
+| id       | string  | ✅   | -      | 节点或者连线 Id                                     |
+| multiple | boolean |      | false  | 是否为多选，如果为 true，不会将上一个选中的元素重置 |
+| toFront  | boolean |      | true   | 是否将选中的元素置顶，默认为 true                   |
+
+示例：
+
+```jsx | pure
+lf.selectElementById(id: string, multiple = false, toFront = true)
+```
+
+### getSelectElements
+
+获取选中的所有元素。
+
+```jsx | pure
+getSelectElements(isIgnoreCheck: boolean): GraphConfigData
+```
+
+| 名称          | 类型    | 必传 | 默认值 | 描述                                                         |
+| :------------ | :------ | :--- | :----- | :----------------------------------------------------------- |
+| isIgnoreCheck | boolean | ✅   | true   | 是否包括 sourceNode 和 targetNode 没有被选中的边, 默认包括。 |
+
+```jsx | pure
+lf.getSelectElements(false);
+```
+
+### clearSelectElements
+
+取消所有元素的选中状态。
+
+```jsx | pure
+lf.clearSelectElements();
+```
+
+### getModelById
+
+基于节点或边 Id 获取其 model。
+
+```jsx | pure
+lf.getModelById("node_id");
+lf.getModelById("edge_id");
+```
+
+### getDataById
+
+基于节点或边 Id 获取其 data。
+
+```jsx | pure
+lf.getDataById("node_id");
+lf.getDataById("edge_id");
+```
+
+### deleteElement
+
+删除元素。
+
+```jsx | pure
+deleteElement(id: string): boolean
+```
+
+| 名称 | 类型   | 必传 | 默认值 | 描述          |
+| :--- | :----- | :--- | :----- | :------------ |
+| id   | String | ✅   |        | 节点或者边 id |
+
+示例：
+
+```jsx | pure
+lf.deleteElement("node_id");
+```
+
+### setElementZIndex
+
+设置元素的 zIndex.
+
+注意：默认堆叠模式下，不建议使用此方法。
+
+参数：
+
+| 名称   | 类型            | 必传 | 默认值 | 描述                                    |
+| :----- | :-------------- | :--- | :----- | :-------------------------------------- |
+| id     | String          | ✅   | -      | 边或者节点 id                           |
+| zIndex | String\| Number | ✅   | -      | 可以传数字，也支持传入`top` 和 `bottom` |
+
+示例：
+
+```jsx | pure
+// 置为顶部
+lf.setElementZIndex("element_id", "top");
+// 置为底部
+lf.setElementZIndex("element_id", "bottom");
+lf.setElementZIndex("element_id", 2000);
+```
+
+### getAreaElement
 
 获取指定区域内的所有元素，此区域必须是 DOM 层。
 
@@ -804,57 +661,94 @@ lf.addElements({
 lf.getAreaElement([100, 100], [500, 500]);
 ```
 
-## getSelectElements
+### setProperties
 
-获取选中的所有元素
-
-```jsx | pure
-getSelectElements(isIgnoreCheck: boolean): GraphConfigData
-```
-
-| 名称          | 类型    | 必传 | 默认值 | 描述                                                         |
-| :------------ | :------ | :--- | :----- | :----------------------------------------------------------- |
-| isIgnoreCheck | boolean | ✅   | true   | 是否包括 sourceNode 和 targetNode 没有被选中的边, 默认包括。 |
+设置节点或者边的自定义属性。
 
 ```jsx | pure
-lf.getSelectElements(false);
+setProperties(id: string, properties: Object): void
 ```
 
-## clearSelectElements
-
-取消所有元素的选中状态
+示例：
 
 ```jsx | pure
-lf.clearSelectElements();
+lf.setProperties("aF2Md2P23moN2gasd", {
+  isRollbackNode: true,
+});
 ```
 
-## getModelById
+### getProperties
 
-基于节点或边 Id 获取其 model
+获取节点或者边的自定义属性。
 
 ```jsx | pure
-lf.getModelById("node_id");
-lf.getModelById("edge_id");
+getProperties(id: string): Object
 ```
 
-## getDataById
-
-基于节点或边 Id 获取其 data
+示例：
 
 ```jsx | pure
-lf.getDataById("node_id");
-lf.getDataById("edge_id");
+lf.getProperties("id");
 ```
 
-## clearData
+### deleteProperty
 
-清空画布
+删除节点属性。
 
 ```jsx | pure
-lf.clearData();
+deleteProperty(id: string, key: string): void
 ```
 
-## updateEditConfig
+示例：
+
+```jsx | pure
+lf.deleteProperty("aF2Md2P23moN2gasd", "isRollbackNode");
+```
+
+### updateAttributes
+
+修改对应元素 model 中的属性, 方法内部就是调用的[graphModel](graph-model-api#updateattributes)。
+
+:::warning{title=注意}
+此方法慎用，除非您对logicflow内部有足够的了解。<br>
+大多数情况下，请使用setProperties、updateText、changeNodeId等方法。<br>
+例如直接使用此方法修改节点的id,那么就是会导致连接到此节点的边的sourceNodeId出现找不到的情况。
+:::
+```jsx | pure
+updateAttributes(id: string, attributes: object): void
+```
+示例：
+
+```jsx | pure
+lf.updateAttributes("node_id_1", { radius: 4 });
+```
+
+## Text 相关
+
+### editText
+
+同[graphModel.editText](graph-model-api#edittext)
+
+### updateText
+
+更新节点或者边的文案。
+
+```jsx | pure
+updateText(id: string, value: string): void
+```
+
+| 名称  | 类型   | 必传 | 默认值 | 描述           |
+| :---- | :----- | :--- | :----- | :------------- |
+| id    | String | ✅   |        | 节点或者边 id  |
+| value | String | ✅   |        | 更新后的文本值 |
+
+示例：
+
+```jsx | pure
+lf.updateText("id", "value");
+```
+
+### updateEditConfig
 
 更新流程编辑基本配置.
 
@@ -866,9 +760,9 @@ lf.updateEditConfig({
 });
 ```
 
-## getEditConfig
+### getEditConfig
 
-获取流程编辑基本配置
+获取流程编辑基本配置。
 
 详细参数见：[editConfig](edit-config-model-api)
 
@@ -876,9 +770,70 @@ lf.updateEditConfig({
 lf.getEditConfig();
 ```
 
-## getPointByClient
+## Graph 相关
 
-获取事件位置相对于画布左上角的坐标
+### setTheme
+
+设置主题, 详情见[主题](theme-api)
+
+### focusOn
+
+定位到画布视口中心。
+
+参数：
+
+| 参数名      | 类型   | 必传 | 默认值 | 描述         |
+| :---------- | :----- | :--- | :----- | :----------- |
+| focusOnArgs | object | ✅   | -      | 定位所需参数 |
+
+示例：
+
+```jsx | pure
+// 定位画布视口中心到node_1元素所处位置
+lf.focusOn({
+  id: "node_1",
+});
+// 定位画布视口中心到坐标[1000, 1000]处
+lf.focusOn({
+  coordinate: {
+    x: 1000,
+    y: 1000,
+  },
+});
+```
+
+### resize
+
+调整画布宽高, 如果 width 或者 height 不传会自动计算画布宽高。
+
+参数：
+
+| 名称   | 类型   | 必传 | 默认值 | 描述     |
+| :----- | :----- | :--- | :----- | :------- |
+| width  | Number |      | -      | 画布的宽 |
+| height | Number |      | -      | 画布的高 |
+
+```jsx | pure
+lf.resize(1200, 600);
+```
+
+### toFront
+
+将某个元素放置到顶部。
+
+如果堆叠模式为默认模式，则将指定元素置顶 zIndex 设置为 9999，原置顶元素重新恢复原有层级 zIndex 设置为 1。
+
+如果堆叠模式为递增模式，则将需指定元素 zIndex 设置为当前最大 zIndex + 1。
+
+示例：
+
+```jsx | pure
+lf.toFront("id");
+```
+
+### getPointByClient
+
+获取事件位置相对于画布左上角的坐标。
 
 画布所在的位置可以是页面任何地方，原生事件返回的坐标是相对于页面左上角的，该方法可以提供以画布左上角为原点的准确位置。
 
@@ -916,50 +871,129 @@ type Point = {
 lf.getPointByClient(event.x, event.y);
 ```
 
-## focusOn
+### getGraphData
 
-定位到画布视口中心
+获取流程绘图数据。
 
-参数：
+```jsx | pure
+// 返回值，如果是应用了adapter插件，且设置为adapterOut，返回为转换后的数据格式，否则为默认的格式
+// 1.2.5版本以后新增了入参，用于某些需要入参的adapterOut的执行，例如内置的BpmnAdapter可能需要传入属性保留字段的数组来保证导出数据中的某些节点属性被正常处理。
+// 这里的入参和引入的Adapter的adapterOut方法除了data以外的其他参数保持一致。
+getGraphData(...params: any): GraphConfigData | unknown
+```
 
-| 参数名      | 类型   | 必传 | 默认值 | 描述         |
-| :---------- | :----- | :--- | :----- | :----------- |
-| focusOnArgs | object | ✅   | -      | 定位所需参数 |
+LogicFlow 默认数据格式。
+
+```jsx | pure
+type GraphConfigData = {
+  nodes: {
+    id?: string;
+    type: string;
+    x: number;
+    y: number;
+    text?: TextConfig;
+    properties?: Record<string, unknown>;
+    zIndex?: number;
+  }[];
+  edges: {
+    id: string;
+    type: string;
+    sourceNodeId: string;
+    targetNodeId: string;
+    startPoint: any;
+    endPoint: any;
+    text: {
+      x: number;
+      y: number;
+      value: string;
+    };
+    properties: {};
+    zIndex?: number;
+    pointsList?: Point[]; // 折线、曲线会输出pointsList
+  }[];
+};
+```
 
 示例：
 
 ```jsx | pure
-// 定位画布视口中心到node_1元素所处位置
-lf.focusOn({
-  id: "node_1",
-});
-// 定位画布视口中心到坐标[1000, 1000]处
-lf.focusOn({
-  coordinate: {
-    x: 1000,
-    y: 1000,
-  },
-});
+lf.getGraphData();
 ```
 
-## resize
+### getGraphRawData
 
-调整画布宽高, 如果 width 或者 height 不传会自动计算画布宽高。
-
-参数：
-
-| 名称   | 类型   | 必传 | 默认值 | 描述     |
-| :----- | :----- | :--- | :----- | :------- |
-| width  | Number |      | -      | 画布的宽 |
-| height | Number |      | -      | 画布的高 |
+获取流程绘图原始数据， 与 getGraphData 区别是该方法获取的数据不会受到 adapter 影响。
 
 ```jsx | pure
-lf.resize(1200, 600);
+getGraphRawData(): GraphConfigData
 ```
 
-## zoom
+示例：
 
-放大缩小画布
+```jsx | pure
+lf.getGraphRawData();
+```
+
+### clearData
+
+清空画布。
+
+```jsx | pure
+lf.clearData();
+```
+
+### renderRawData
+
+渲染图原始数据，和`render`的区别是在使用`adapter`后，如何还想渲染 logicflow 格式的数据，可以用此方法。
+
+```jsx | pure
+const lf = new LogicFlow({
+  ...
+})
+lf.renderRawData({
+  nodes: [],
+  edges: []
+})
+```
+
+### render
+
+渲染图数据。
+
+```jsx | pure
+const lf = new LogicFlow({
+  ...
+})
+lf.render(graphData)
+```
+
+## History 相关
+
+### undo
+
+历史记录操作-返回上一步。
+
+示例：
+
+```jsx | pure
+lf.undo();
+```
+
+### redo
+
+历史记录操作-恢复下一步。
+
+示例：
+
+```jsx | pure
+lf.redo();
+```
+
+## Resize 相关
+
+### zoom
+
+放大缩小画布。
 
 参数：
 
@@ -981,7 +1015,7 @@ lf.zoom(2);
 lf.zoom(2, [100, 100]);
 ```
 
-## resetZoom
+### resetZoom
 
 重置图形的缩放比例为默认，默认是 1。
 
@@ -991,7 +1025,7 @@ lf.zoom(2, [100, 100]);
 lf.resetZoom();
 ```
 
-## setZoomMiniSize
+### setZoomMiniSize
 
 设置图形缩小时，能缩放到的最小倍数。参数一般为 0-1 之间，默认 0.2。
 
@@ -1011,7 +1045,7 @@ setZoomMiniSize(size: number): void
 lf.setZoomMiniSize(0.3);
 ```
 
-## setZoomMaxSize
+### setZoomMaxSize
 
 设置图形放大时，能放大到的最大倍数，默认 16。
 
@@ -1031,16 +1065,16 @@ setZoomMaxSize(size: number): void
 lf.setZoomMaxSize(20);
 ```
 
-## getTransform
+### getTransform
 
-获取当前画布的放大缩小值
+获取当前画布的放大缩小值。
 
 ```jsx | pure
 const transform = lf.getTransform();
 console.log(transform);
 ```
 
-## translate
+### translate
 
 平移图
 
@@ -1055,15 +1089,7 @@ console.log(transform);
 lf.translate(100, 100);
 ```
 
-## translateCenter
-
-图形画布居中显示
-
-```jsx | pure
-lf.translateCenter();
-```
-
-## resetTranslate
+### resetTranslate
 
 还原图形为初始位置
 
@@ -1071,7 +1097,16 @@ lf.translateCenter();
 lf.resetTranslate();
 ```
 
-## fitView
+### translateCenter
+
+图形画布居中显示。
+
+```jsx | pure
+lf.translateCenter();
+```
+
+
+### fitView
 
 将整个流程图缩小到画布能全部显示。
 
@@ -1086,25 +1121,27 @@ lf.resetTranslate();
 lf.fitView(deltaX, deltaY);
 ```
 
-## openEdgeAnimation
+### openEdgeAnimation
 
-开启边的动画
+开启边的动画。
 
 ```jsx | pure
 lf.openEdgeAnimation(edgeId: string):void;
 ```
 
-## closeEdgeAnimation
+### closeEdgeAnimation
 
-关闭边的动画
+关闭边的动画。
 
 ```jsx | pure
 lf.closeEdgeAnimation(edgeId: string):void;
 ```
 
-## on
+## 事件系统 相关
 
-图的监听事件，更多事件请查看[事件](event-center-api)
+### on
+
+图的监听事件，更多事件请查看[事件](event-center-api)。
 
 ```jsx | pure
 on(evt: string, callback: Function): this
@@ -1135,9 +1172,9 @@ lf.on("element:click", (args) => {
 });
 ```
 
-## off
+### off
 
-删除事件监听
+删除事件监听。
 
 ```jsx | pure
 off(evt: string, callback: Function): this
@@ -1161,9 +1198,9 @@ lf.off("element:click", () => {
 });
 ```
 
-## once
+### once
 
-事件监听一次
+事件监听一次。
 
 ```jsx | pure
 once(evt: string, callback: Function): this
@@ -1184,9 +1221,9 @@ lf.once("node:click", () => {
 });
 ```
 
-## emit
+### emit
 
-触发事件
+触发事件。
 
 ```jsx | pure
 emit(evt: string, ...args): this
@@ -1203,24 +1240,4 @@ emit(evt: string, ...args): this
 
 ```jsx | pure
 lf.emit("custom:button-click", model);
-```
-
-## undo
-
-历史记录操作-返回上一步
-
-示例：
-
-```jsx | pure
-lf.undo();
-```
-
-## redo
-
-历史记录操作-恢复下一步
-
-示例：
-
-```jsx | pure
-lf.redo();
 ```

--- a/sites/docs/docs/api/index.en-US.md
+++ b/sites/docs/docs/api/index.en-US.md
@@ -15,8 +15,48 @@ table td:first-of-type {
 
 Usage
 ```jsx | pure
-const lf = new LogicFlow(options: Options);
-lf.XX();
+// create container
+<div id="container"></div>;
+
+// prepare data
+const data = {
+  // node data
+  nodes: [
+    {
+      id: '21',
+      type: 'rect',
+      x: 100,
+      y: 200,
+      text: 'rect node',
+    },
+    {
+      id: '50',
+      type: 'circle',
+      x: 300,
+      y: 400,
+      text: 'circle node',
+    },
+  ],
+  // edge data
+  edges: [
+    {
+      type: 'polyline',
+      sourceNodeId: '50',
+      targetNodeId: '21',
+    },
+  ],
+};
+
+// create instance
+const lf = new LogicFlow({
+  container: document.querySelector('#container'),
+  width: 700,
+  height: 600,
+  grid: true,
+});
+
+// render instance
+lf.render(data);
 ```
 
 ## an actual example
@@ -26,73 +66,115 @@ All node instance operations on the flowchart, as well as events, and behavioral
 `LogicFlow` configuration items: [constructor](detail/constructor)
 
 ## method
-| Options | Description         |
-| :------------------------ | --------------------------- |
-| [register](detail#register) |Register nodes, edges.|
-| [batchRegister](detail#batchregister) | Batch registration.|
-| [render](detail#render) | Render graph data. |
-| [renderRawData](detail#renderrawdata) | Render map raw data that you also want to render in logicflow format after using `adapter`. |
-| [setTheme](api/theme-api) | Set the theme |
-| [changeNodeType](detail#changenodetype) | Modify the node type. |
-| [getNodeEdges](detail#getnodeedges) | Get the `model` of all edges connected to the node.|
-| [addNode](detail#addnode) | Add nodes to the graph. |
-| [deleteNode](detail#deletenode) | Delete a node from the graph, and if there is a line connecting this node, delete the line as well. |
-| [cloneNode](detail#clonenode) | Clone the node. |
-| [changeNodeId](detail#changenodeid) | Modify the `id` of a node, if no new `id` is passed, one will be created internally. |
-| [getNodeModelById](detail#getnodemodelbyid) | Get the `model` of the node. |
-| [getNodeDataById](detail#getnodedatabyid) | Get the `model` data of the node.  |
-| [getNodeIncomingNode](detail#getnodeincomingnode) | Get all higher level nodes of the node.  |
-| [getNodeOutgoingNode](detail#getnodeoutgoingnode) | Get all next-level nodes of the node. |
-| [getNodeIncomingEdge](detail#getnodeincomingedge) | Get all edges that end at this node. |
-| [getNodeOutgoingEdge](detail#getnodeoutgoingedge) | Get all edges that start at this node. |
-| [addEdge](detail#addedge) | Create edges connecting two nodes. |
-| [deleteEdge](detail#deleteedge) | Delete edges based on edge `id`. |
-| [deleteEdgeByNodeId](detail#deleteedgebynodeid) | Delete an edge connected to the specified node, based on the edge's start and end points. |
-| [getEdgeModelById](detail#getedgemodelbyid) | Get the `model` of an edge based on the edge `id`. |
-| [getEdgeModels](detail#getedgemodels) | Get the `model` of the edge that satisfies the condition. |
-| [changeEdgeId](detail#changeedgeid) |  Modify the `id` of the edge, if no new `id` is passed, one will be created internally. |
-| [changeEdgeType](detail#changeedgetype) | Switch the type of the edge. |
-| [getEdgeDataById](detail#getedgedatabyid) | Get the data of the edge by `id` |
-| [setDefaultEdgeType](detail#setdefaultedgetype) | Set the type of the edge, i.e. set the type of the linkage that will be drawn manually by the user directly at the node. |
-| editText | same with [graphModel.editText](api/graph-model-api#edittext)。 |
-| [updateText](detail#updatetext) | Update the text of the node or edge. |
-| [deleteElement](detail#deleteelement) | Delete an element. |
-| [selectElementById](detail#selectelementbyid) | Select the graphic.  |
-| [getGraphData](detail#getgraphdata) | Get process plot data. |
-| [getGraphRawData](detail#getgraphrawdata) | Get the raw data of the process graph, the difference with `getGraphData` is that the data obtained by this method will not be affected by the `adapter`. |
-| [setProperties](detail#setproperties) | Set the custom properties of the node or edge. |
-| [deleteProperty](detail#deleteproperty) | Delete a node attribute.  |
-| [getProperties](detail#getproperties) | Get the custom attributes of the node or edge. |
-| [updateAttributes](detail#updateattributes) | Modify the attributes of the corresponding element `model`. |
-| [toFront](detail#tofront) | Place an element on top.  |
-| [setElementZIndex](detail#setelementzindex) | Set the `zIndex` of the element. |
-| [addElements](detail#addelements) | Add nodes and edges in bulk. |
-| [getAreaElement](detail#getareaelement) | Get all elements in the specified region (this region must be a DOM level).  |
-| [getSelectElements](detail#getselectelements) | Get all selected elements.  |
-| [clearSelectElements](detail#clearselectelements) | Unselect all elements. |
-| [getModelById](detail#getmodelbyid) | Get the `model` of a node or edge based on its `id`. |
-| [getDataById](detail#getdatabyid) | Get the `data` of a node or edge based on its `id`. |
-| [clearData](detail#cleardata) | Clear the canvas.  |
-| [updateEditConfig](detail#updateeditconfig) | Update the basic configuration of the process editor. |
-| [getEditConfig](detail#geteditconfig) | Get the process editing basic configuration |
-| [getPointByClient](detail#getpointbyclient) | Get the coordinates of the event position relative to the upper-left corner of the canvas |
-| [focusOn](detail#focuson) | Position to the center of the canvas viewport |
-| [resize](detail#resize) | Adjust the width and height of the canvas, if `width` or `height` is not passed, the width and height of the canvas will be calculated automatically. |
-| [zoom](detail#zoom) | Zoom in and out of the canvas |
-| [resetZoom](detail#resetzoom) | Reset the zoom ratio of the drawing to the default, which is 1. |
-| [setZoomMiniSize](detail#setzoomminisize) | Set the minimum size that the graphic can be scaled to when zoomed out. The parameter is usually between 0 and 1, the default is 0.2. |
-| [setZoomMaxSize](detail#setzoommaxsize) | Sets the maximum zoom level that the graphic can be zoomed to when zooming in, default is 16. |
-| [getTransform](detail#gettransform) | Get the zoom value of the current canvas |
-| [translate](detail#translate) | Panning |
-| [translateCenter](detail#translatecenter) | Centers the canvas of the graph. |
-| [resetTranslate](detail#resettranslate) | Restore the graph to its original position |
-| [fitView](detail#fitview) | Reduces the entire flowchart to the point where the canvas can be displayed in its entirety.  |
-| [openEdgeAnimation](detail#openedgeanimation) | Turn on edge animation. |
-| [closeEdgeAnimation](detail#closeedgeanimation) | Turn off the animation of the edges. |
-| [on](detail#on) | Figure of listening events, for more events see [events](api/event-center-api) |
-| [off](detail#off) | Deleting an event listener |
-| [once](detail#once) | Listen to an event once |
-| [emit](detail#emit) | Trigger event |
-| [undo](detail#undo) | History action-return to previous step |
-| [redo](detail#redo) | History Action - Resume Next |
-<!-- | [](detail#) | 。 | -->
+
+### Register Related
+
+| Option  | Description               |
+|:----------------------|-------------------------|
+| [register](detail#register) | Register custom nodes, edges. |
+| [batchRegister](detail#batchregister) | Batch register.        |
+
+### Node Related
+
+| Option  | Description               |
+|:-----------------------|-------------------------|
+| [addNode](detail#addnode)           | Add nodes to the graph.     |
+| [deleteNode](detail#deletenode)     | Deletes a node on the graph, and if there is a line attached to this node, then also deletes the line. |
+| [cloneNode](detail#clonenode)       | Clone a node.        |
+| [changeNodeId](detail#changenodeid) | Modify the id of the node, if no new id is passed, one will be created internally automatically.             |
+| [changeNodeType](detail#changenodetype)           | Modify node type.      |
+| [getNodeModelById](detail#getnodemodelbyid)       | Get the `model` of the node |
+| [getNodeDataById](detail#getnodedatabyid)         | Get the `model` data of a node. |
+| [getNodeIncomingEdge](detail#getnodeincomingedge) | Get all the edges that `end` at this node.|
+| [getNodeOutgoingEdge](detail#getnodeoutgoingedge) | Get all the edges that `start` at this node. |
+| [getNodeIncomingNode](detail#getnodeincomingnode) | Get all parent nodes of the node. |
+| [getNodeOutgoingNode](detail#getnodeoutgoingnode) | Get all the next-level nodes of the node. |
+
+### Edge Related
+
+| Option  | Description               |
+|:-----------------------|-------------------------|
+| [setDefaultEdgeType](detail#setdefaultedgetype)   | Set the type of edge, i.e. set the type of linkage drawn directly by the user at the node.|
+| [addEdge](detail#addedge)           | Create an edge connecting two nodes.  |
+| [getEdgeDataById](detail#getedgedatabyid)         | Get edge data by `id`. |
+| [getEdgeModelById](detail#getedgemodelbyid)       | Get the model of the edge based on the its `id`.        |
+| [getEdgeModels](detail#getedgemodels)             | Get the model of the edge that satisfies the condition. |
+| [changeEdgeId](detail#changeedgeid) | Modify the edge id. If a new id is not passed, one will be created internally automatically.            |
+| [changeEdgeType](detail#changeedgetype)           | Switch type of the edge.      |
+| [deleteEdge](detail#deleteedge)     | Delete an edge based on its id.  |
+| [deleteEdgeByNodeId](detail#deleteedgebynodeid)   | Deletes an edge of the specified type, based on the start and end points of the edge, and can pass only one of them.       |
+| [getNodeEdges](detail#getnodeedges) | Get the model of all edges connected by the node.          |
+
+### Element Related
+
+| Option  | Description               |
+|:-----------------------|-------------------------|
+| [addElements](detail#addelements)   | Batch add nodes and edges.    |
+| [selectElementById](detail#selectelementbyid)     | Select the graph.       |
+| [getSelectElements](detail#getselectelements)     | Get all elements selected.   |
+| [clearSelectElements](detail#clearselectelements) | Uncheck all elements. |
+| [getModelById](detail#getmodelbyid) | Get the `model` of a node or edge based on its `id`.   |
+| [getDataById](detail#getdatabyid)   | Get the `data` of a node or edge based on its `id`.      |
+| [deleteElement](detail#deleteelement)             | Delete the element by id.      |
+| [setElementZIndex](detail#setelementzindex)       | Set the `zIndex` of the element.|
+| [getAreaElement](detail#getareaelement)           | Gets all the elements in the specified region, which must be a DOM layer.  |
+| [setProperties](detail#setproperties)             | Set the custom properties of nodes or edges. |
+| [getProperties](detail#getproperties)             | Get the custom properties of a node or an edge. |
+| [deleteProperty](detail#deleteproperty) | Delete node attributes.  |
+| [updateAttributes](detail#updateattributes)       | Modifies an attribute in the corresponding element model, which is called graphModel inside the method.         |
+
+### Text Related
+
+| Option  | Description               |
+|:-----------------------|-------------------------|
+| [editText](detail#edittext)            | Show text editing box for nodes and edges, entering edit mode, equivalent to [graphModel.editText](api/graph-model-api#edittext).      |
+| [updateText](detail#updatetext)     | Update the node or edge text.  |
+| [updateEditConfig](detail#updateeditconfig)       | Update the basic configuration of the flow editor.  |
+| [getEditConfig](detail#geteditconfig)             | Get the basic configuration of the flow editor.  |
+
+### Graph Related
+
+| Option  | Description               |
+|:-----------------------|-------------------------|
+| [setTheme](api/theme-api)           | Set the theme.        |
+| [focusOn](detail#focuson)           | Position to the center of the canvas viewport.   |
+| [resize](detail#resize)             | Adjusts the width and height of the canvas, if the width or height is not passed, the width and height of the canvas will be calculated automatically.     |
+| [toFront](detail#tofront)           | Places an element to the top.  |
+| [getPointByClient](detail#getpointbyclient)       | Get the coordinates of the event location relative to the top left corner of the canvas.           |
+| [getGraphData](detail#getgraphdata) | Get flow graphing data.    |
+| [getGraphRawData](detail#getgraphrawdata)         | Get the raw data of the flow graph. The difference with getGraphData is that the data obtained by this method is not affected by the `adapter`. |
+| [clearData](detail#cleardata)       | Clear the canvas.      |
+| [renderRawData](detail#renderrawdata)             | Rendering of the raw graph data. The difference with render is that after using `adapter`, you can use this method if you still want to render the data in logicflow format.  |
+| [render](detail#render)             | Render graph data.     |
+
+### History Related
+
+| Option  | Description               |
+|:-----------------------|-------------------------|
+| [undo](detail#undo) | History operation - Back to previous step.|
+| [redo](detail#redo) | History operation - Resume next.|
+
+### Resize Related
+
+| Option  | Description               |
+|:-----------------------|-------------------------|
+| [zoom](detail#zoom) | Zoom in or out on the canvas.      |
+| [resetZoom](detail#resetzoom)       | Reset the zoom ratio of the drawing to the default, which is 1.          |
+| [setZoomMiniSize](detail#setzoomminisize)         | Sets the minimum number of times the graph can be scaled when it is reduced. The parameter takes values from 0 to 1. Default 0.       |
+| [setZoomMaxSize](detail#setzoommaxsize)           | Set the maximum zoom scale when zooming in; default is 16.     |
+| [getTransform](detail#gettransform) | Get the zoom in/out value of the current canvas.|
+| [translate](detail#translate)       | Panning graph.         |
+| [resetTranslate](detail#resettranslate)           | Restore the graph to its original position.  |
+| [translateCenter](detail#translatecenter)         | Graphics canvas centering.    |
+| [fitView](detail#fitview)           | Reduce the entire flowchart to a size where the entire canvas can be displayed.            |
+| [openEdgeAnimation](detail#openedgeanimation)     | Enable edge animations.   |
+| [closeEdgeAnimation](detail#closeedgeanimation)   | Disable edge animations.  |
+
+### Event System Related
+
+| Option  | Description               |
+|:-----------------------|-------------------------|
+| [on](detail#on)     | Event listener for the graph; see [Events](api/event-center-api) for more events.    |
+| [off](detail#off)   | Remove event listener.      |
+| [once](detail#once) | Event listener that triggers only once.      |
+| [emit](detail#emit) | Trigger an event.        |

--- a/sites/docs/docs/api/index.md
+++ b/sites/docs/docs/api/index.md
@@ -15,12 +15,12 @@ table td:first-of-type {
 
 使用方式
 ```jsx | pure
-// create container
+// 创建容器
 <div id="container"></div>;
 
-// prepare data
+// 准备图数据
 const data = {
-  // node data
+  // 节点
   nodes: [
     {
       id: '21',
@@ -37,7 +37,7 @@ const data = {
       text: 'circle node',
     },
   ],
-  // edge data
+  // 边
   edges: [
     {
       type: 'polyline',
@@ -46,13 +46,16 @@ const data = {
     },
   ],
 };
-// render instance
+
+// 创建实例
 const lf = new LogicFlow({
   container: document.querySelector('#container'),
   width: 700,
   height: 600,
+  grid: true,
 });
 
+// 渲染实例
 lf.render(data);
 ```
 
@@ -62,74 +65,116 @@ lf.render(data);
 
 `LogicFlow`配置项:  [constructor](detail/constructor)
 
-## 方法
+## 实例方法
+
+### Register 相关
+
 | 选项  | 描述           |
-|:--------------------------------------------------|------------------------------------------------------------|
-| [register](detail#register)         | 注册节点、边。      |
-| [batchRegister](detail#batchregister)             | 批量注册。        |
-| [render](detail#render)             | 渲染图数据。       |
-| [renderRawData](detail#renderrawdata)             | 渲染图原始数据，在使用`adapter`后，还想渲染 logicflow 格式的数据。  |
-| [setTheme](api/theme-api)           | 设置主题。        |
-| [changeNodeType](detail#changenodetype)           | 修改节点类型。      |
-| [getNodeEdges](detail#getnodeedges) | 获取节点连接的所有边的`model`。          |
+|:--------------------|-------------------------|
+| [register](detail#register) | 注册自定义节点、边。|
+| [batchRegister](detail#batchregister) | 批量注册。        |
+
+### Node 相关
+
+| 选项  | 描述           |
+|:---------------------|-------------------------|
 | [addNode](detail#addnode)           | 在图上添加节点。     |
 | [deleteNode](detail#deletenode)     | 删除图上的节点, 如果这个节点上有连接线，则同时删除线。 |
 | [cloneNode](detail#clonenode)       | 克隆节点。        |
 | [changeNodeId](detail#changenodeid) | 修改节点的`id`， 如果不传新的`id`，会内部自动创建一个。             |
+| [changeNodeType](detail#changenodetype)           | 修改节点类型。      |
 | [getNodeModelById](detail#getnodemodelbyid)       | 获取节点的`model`。|
 | [getNodeDataById](detail#getnodedatabyid)         | 获取节点的`model`数据。|
-| [getNodeIncomingNode](detail#getnodeincomingnode) | 获取节点所有的上一级节点。|
-| [getNodeOutgoingNode](detail#getnodeoutgoingnode) | 获取节点所有的下一级节点。|
 | [getNodeIncomingEdge](detail#getnodeincomingedge) | 获取所有以此节点为终点的边。 |
 | [getNodeOutgoingEdge](detail#getnodeoutgoingedge) | 获取所有以此节点为起点的边。 |
+| [getNodeIncomingNode](detail#getnodeincomingnode) | 获取节点所有的上一级节点。|
+| [getNodeOutgoingNode](detail#getnodeoutgoingnode) | 获取节点所有的下一级节点。|
+
+### Edge 相关
+
+| 选项  | 描述           |
+|:---------------------|-------------------------|
+| [setDefaultEdgeType](detail#setdefaultedgetype)   | 设置边的类型, 也就是设置在节点直接由用户手动绘制的连线类型。|
 | [addEdge](detail#addedge)           | 创建连接两个节点的边。  |
-| [deleteEdge](detail#deleteedge)     | 基于边`id`删除边。  |
-| [deleteEdgeByNodeId](detail#deleteedgebynodeid)   | 删除与指定节点相连的边, 基于边起点和终点。       |
+| [getEdgeDataById](detail#getedgedatabyid)         | 通过`id`获取边的数据。|
 | [getEdgeModelById](detail#getedgemodelbyid)       | 基于边 `id` 获取边的`model`。        |
 | [getEdgeModels](detail#getedgemodels)             | 获取满足条件边的`model`。             |
 | [changeEdgeId](detail#changeedgeid) | 修改边的 `id`， 如果不传新的 `id`，会内部自动创建一个。            |
 | [changeEdgeType](detail#changeedgetype)           | 切换边的类型。      |
-| [getEdgeDataById](detail#getedgedatabyid)         | 通过`id`获取边的数据。|
-| [setDefaultEdgeType](detail#setdefaultedgetype)   | 设置边的类型, 也就是设置在节点直接由用户手动绘制的连线类型。|
-| editText            | 同[graphModel.editText](api/graph-model-api#edittext)。      |
-| [updateText](detail#updatetext)     | 更新节点或者边的文案。  |
-| [deleteElement](detail#deleteelement)             | 删除元素。        |
-| [selectElementById](detail#selectelementbyid)     | 将图形选中。       |
-| [getGraphData](detail#getgraphdata) | 获取流程绘图数据。    |
-| [getGraphRawData](detail#getgraphrawdata)         | 获取流程绘图原始数据， 与 `getGraphData` 区别是该方法获取的数据不会受到 `adapter` 影响。 |
-| [setProperties](detail#setproperties)             | 设置节点或者边的自定义属性。 |
-| [deleteProperty](detail#deleteproperty)           | 删除节点属性。      |
-| [getProperties](detail#getproperties)             | 获取节点或者边的自定义属性。 |
-| [updateAttributes](detail#updateattributes)       | 修改对应元素 `model` 中的属性。         |
-| [toFront](detail#tofront)           | 将某个元素放置到顶部。  |
-| [setElementZIndex](detail#setelementzindex)       | 设置元素的 `zIndex`。|
+| [deleteEdge](detail#deleteedge)     | 基于边`id`删除边。  |
+| [deleteEdgeByNodeId](detail#deleteedgebynodeid)   | 删除与指定节点相连的边, 基于边起点和终点。       |
+| [getNodeEdges](detail#getnodeedges) | 获取节点连接的所有边的`model`。          |
+
+### Element 相关
+
+| 选项  | 描述           |
+|:---------------------|-------------------------|
 | [addElements](detail#addelements)   | 批量添加节点和边。    |
-| [getAreaElement](detail#getareaelement)           | 获取指定区域内的所有元素(此区域必须是 DOM 层)。  |
+| [selectElementById](detail#selectelementbyid)     | 将图形选中。       |
 | [getSelectElements](detail#getselectelements)     | 获取选中的所有元素。   |
 | [clearSelectElements](detail#clearselectelements) | 取消所有元素的选中状态。 |
 | [getModelById](detail#getmodelbyid) | 基于节点或边 `id` 获取其 `model`。     |
 | [getDataById](detail#getdatabyid)   | 基于节点或边 `id` 获取其 `data`。      |
-| [clearData](detail#cleardata)       | 清空画布。        |
+| [deleteElement](detail#deleteelement)             | 删除元素。        |
+| [setElementZIndex](detail#setelementzindex)       | 设置元素的 `zIndex`。|
+| [getAreaElement](detail#getareaelement)           | 获取指定区域内的所有元素(此区域必须是 DOM 层)。  |
+| [setProperties](detail#setproperties)             | 设置节点或者边的自定义属性。 |
+| [getProperties](detail#getproperties)             | 获取节点或者边的自定义属性。 |
+| [deleteProperty](detail#deleteproperty)           | 删除节点属性。      |
+| [updateAttributes](detail#updateattributes)       | 修改对应元素 `model` 中的属性。         |
+
+### Text 相关
+
+| 选项  | 描述           |
+|:---------------------|-------------------------|
+| [editText](detail#edittext)            | 显示节点、连线文本编辑框, 进入编辑状态，同[graphModel.editText](api/graph-model-api#edittext)。      |
+| [updateText](detail#updatetext)     | 更新节点或者边的文案。  |
 | [updateEditConfig](detail#updateeditconfig)       | 更新流程编辑基本配置。  |
 | [getEditConfig](detail#geteditconfig)             | 获取流程编辑基本配置。  |
-| [getPointByClient](detail#getpointbyclient)       | 获取事件位置相对于画布左上角的坐标。           |
+
+### Graph 相关
+
+| 选项  | 描述           |
+|:---------------------|-------------------------|
+| [setTheme](api/theme-api)           | 设置主题。        |
 | [focusOn](detail#focuson)           | 定位到画布视口中心。   |
 | [resize](detail#resize)             | 调整画布宽高, 如果`width` 或者`height`不传会自动计算画布宽高。     |
+| [toFront](detail#tofront)           | 将某个元素放置到顶部。  |
+| [getPointByClient](detail#getpointbyclient)       | 获取事件位置相对于画布左上角的坐标。           |
+| [getGraphData](detail#getgraphdata) | 获取流程绘图数据。    |
+| [getGraphRawData](detail#getgraphrawdata)         | 获取流程绘图原始数据， 与 `getGraphData` 区别是该方法获取的数据不会受到 `adapter` 影响。 |
+| [clearData](detail#cleardata)       | 清空画布。        |
+| [renderRawData](detail#renderrawdata)             | 渲染图原始数据，在使用`adapter`后，还想渲染 logicflow 格式的数据。  |
+| [render](detail#render)             | 渲染图数据。       |
+
+### History 相关
+
+| 选项  | 描述           |
+|:---------------------|-------------------------|
+| [undo](detail#undo) | 历史记录操作-返回上一步。|
+| [redo](detail#redo) | 历史记录操作-恢复下一步。|
+
+### Resize 相关
+
+| 选项  | 描述           |
+|:---------------------|-------------------------|
 | [zoom](detail#zoom) | 放大缩小画布。      |
 | [resetZoom](detail#resetzoom)       | 重置图形的缩放比例为默认，默认是 1。          |
 | [setZoomMiniSize](detail#setzoomminisize)         | 设置图形缩小时，能缩放到的最小倍数。参数一般为 0-1 之间，默认 0.2。       |
 | [setZoomMaxSize](detail#setzoommaxsize)           | 设置图形放大时，能放大到的最大倍数，默认 16。     |
 | [getTransform](detail#gettransform) | 获取当前画布的放大缩小值。|
 | [translate](detail#translate)       | 平移图。         |
-| [translateCenter](detail#translatecenter)         | 图形画布居中显示。    |
 | [resetTranslate](detail#resettranslate)           | 还原图形为初始位置。   |
+| [translateCenter](detail#translatecenter)         | 图形画布居中显示。    |
 | [fitView](detail#fitview)           | 将整个流程图缩小到画布能全部显示。            |
 | [openEdgeAnimation](detail#openedgeanimation)     | 开启边的动画。      |
 | [closeEdgeAnimation](detail#closeedgeanimation)   | 关闭边的动画。      |
+
+### 事件系统 相关
+
+| 选项  | 描述           |
+|:---------------------|-------------------------|
 | [on](detail#on)     | 图的监听事件，更多事件请查看[事件](api/event-center-api)。    |
 | [off](detail#off)   | 删除事件监听。      |
 | [once](detail#once) | 事件监听一次。      |
 | [emit](detail#emit) | 触发事件。        |
-| [undo](detail#undo) | 历史记录操作-返回上一步。|
-| [redo](detail#redo) | 历史记录操作-恢复下一步。|
-


### PR DESCRIPTION
改动点：
    1. lf实例上的方法进行分类展示
    2. 完善句子标点
    3. lf.register方式实例更换，原先示例不太友好，本地copy下来有报错