### PR TITLE
feat(extension): 支持导出节点中的网络图片

### DIFF
--- a/examples/feature-examples/.umirc.ts
+++ b/examples/feature-examples/.umirc.ts
@@ -117,6 +117,11 @@ export default defineConfig({
           name: 'MiniMap 插件',
           component: './extensions/mini-map',
         },
+        {
+          path: '/extension/snapshot',
+          name: 'Snapshot 插件',
+          component: './extensions/snapshot',
+        },
       ],
     },
   ],

--- a/examples/feature-examples/src/pages/extensions/snapshot/ImageNode.ts
+++ b/examples/feature-examples/src/pages/extensions/snapshot/ImageNode.ts
@@ -1,0 +1,35 @@
+import { RectNode, RectNodeModel, h } from '@logicflow/core'
+
+class ImageModel extends RectNodeModel {
+  initNodeData(data: any) {
+    super.initNodeData(data)
+    this.width = 80
+    this.height = 60
+  }
+}
+
+class ImageNode extends RectNode {
+  getImageHref() {
+    return 'https://dpubstatic.udache.com/static/dpubimg/0oqFX1nvbD/cloud.png'
+  }
+  getShape() {
+    const { x, y, width, height } = this.props.model
+    const href = this.getImageHref()
+    const attrs = {
+      x: x - (1 / 2) * width,
+      y: y - (1 / 2) * height,
+      width,
+      height,
+      href,
+      // 根据宽高缩放
+      preserveAspectRatio: 'none meet',
+    }
+    return h('g', {}, [h('image', { ...attrs })])
+  }
+}
+
+export default {
+  type: 'image',
+  view: ImageNode,
+  model: ImageModel,
+}

--- a/examples/feature-examples/src/pages/extensions/snapshot/index.less
+++ b/examples/feature-examples/src/pages/extensions/snapshot/index.less
@@ -1,0 +1,8 @@
+.viewport {
+  height: calc(100vh - 250px);
+  overflow: hidden;
+}
+
+.preview {
+  width: 100%;
+}

--- a/examples/feature-examples/src/pages/extensions/snapshot/index.tsx
+++ b/examples/feature-examples/src/pages/extensions/snapshot/index.tsx
@@ -1,0 +1,234 @@
+import LogicFlow from '@logicflow/core'
+import { Snapshot } from '@logicflow/extension'
+
+import { Button, Card, Col, Divider, Flex, Row, Space } from 'antd'
+import { useEffect, useRef, useState } from 'react'
+import styles from './index.less'
+
+import '@logicflow/core/es/index.css'
+import '@logicflow/extension/es/index.css'
+import ImageNode from './ImageNode'
+
+const config: Partial<LogicFlow.Options> = {
+  isSilentMode: false,
+  stopScrollGraph: false,
+  stopZoomGraph: false,
+  stopMoveGraph: true,
+  style: {
+    rect: {
+      rx: 5,
+      ry: 5,
+      strokeWidth: 2,
+    },
+    circle: {
+      fill: '#f5f5f5',
+      stroke: '#666',
+    },
+    ellipse: {
+      fill: '#dae8fc',
+      stroke: '#6c8ebf',
+    },
+    polygon: {
+      fill: '#d5e8d4',
+      stroke: '#82b366',
+    },
+    diamond: {
+      fill: '#ffe6cc',
+      stroke: '#d79b00',
+    },
+    text: {
+      color: '#b85450',
+      fontSize: 12,
+    },
+  },
+}
+
+const data = {
+  nodes: [
+    {
+      id: '1',
+      type: 'rect',
+      x: 150,
+      y: 100,
+      text: '矩形',
+    },
+    {
+      id: '2',
+      type: 'circle',
+      x: 350,
+      y: 100,
+      text: '圆形',
+    },
+    {
+      id: '3',
+      type: 'image',
+      x: 550,
+      y: 100,
+      text: '云',
+    },
+    {
+      id: '4',
+      type: 'polygon',
+      x: 150,
+      y: 250,
+      text: '多边形',
+    },
+    {
+      id: '5',
+      type: 'image',
+      x: 350,
+      y: 250,
+      text: '菱形',
+    },
+    {
+      id: '6',
+      type: 'text',
+      x: 550,
+      y: 250,
+      text: '纯文本节点',
+    },
+    {
+      id: '7',
+      type: 'html',
+      x: 150,
+      y: 400,
+      text: 'html节点',
+    },
+  ],
+  edges: [
+    {
+      id: 'e_1',
+      type: 'polyline',
+      sourceNodeId: '1',
+      targetNodeId: '2',
+    },
+    {
+      id: 'e_2',
+      type: 'polyline',
+      sourceNodeId: '2',
+      targetNodeId: '3',
+    },
+    {
+      id: 'e_3',
+      type: 'polyline',
+      sourceNodeId: '4',
+      targetNodeId: '5',
+    },
+  ],
+}
+
+/**
+ * 框选插件 Snapshot 示例
+ */
+export default function SnapshotExample() {
+  const lfRef = useRef<LogicFlow>()
+  const containerRef = useRef<HTMLDivElement>(null)
+  const [blobData, setBlobData] = useState('')
+  const [base64Data, setBase64Data] = useState('')
+
+  // 初始化 LogicFlow
+  useEffect(() => {
+    if (!lfRef.current) {
+      const lf = new LogicFlow({
+        ...config,
+        container: containerRef.current!,
+        grid: {
+          size: 20,
+        },
+        plugins: [Snapshot as any],
+      })
+      lf.register(ImageNode)
+
+      lf.on(
+        'selection:selected-area',
+        ({ topLeft, bottomRight }: Record<string, LogicFlow.PointTuple>) => {
+          console.log('get selection area:', topLeft, bottomRight)
+        },
+      )
+      lf.render(data)
+      lfRef.current = lf
+    }
+  }, [])
+
+  const handleGetSnapshot = () => {
+    if (lfRef.current) {
+      lfRef.current.getSnapshot()
+    }
+  }
+
+  const handlePreviewSnapshotBlob = () => {
+    if (lfRef.current) {
+      setBase64Data('')
+      lfRef.current
+        .getSnapshotBlob('#FFFFFF')
+        .then(
+          ({
+            data,
+            width,
+            height,
+          }: {
+            data: Blob
+            width: number
+            height: number
+          }) => {
+            setBlobData(window.URL.createObjectURL(data))
+            console.log('width, height ', width, height)
+          },
+        )
+    }
+  }
+
+  const handlePreviewSnapshotBase64 = () => {
+    if (lfRef.current) {
+      setBlobData('')
+      lfRef.current
+        .getSnapshotBase64('#FFFFFF')
+        .then(
+          ({
+            data,
+            width,
+            height,
+          }: {
+            data: string
+            width: number
+            height: number
+          }) => {
+            setBase64Data(data)
+            console.log('width, height ', width, height)
+          },
+        )
+    }
+  }
+
+  return (
+    <Card title="LogicFlow Extension - Snapshot">
+      <Flex wrap="wrap" gap="middle" align="center" justify="space-between">
+        <Space>
+          <Button onClick={handleGetSnapshot}>下载快照</Button>
+          <Button onClick={handlePreviewSnapshotBlob}>预览(blob)</Button>
+          <Button onClick={handlePreviewSnapshotBase64}>预览(base64)</Button>
+        </Space>
+      </Flex>
+      <Divider />
+      <Row>
+        <Col span={12}>
+          <div ref={containerRef} id="graph" className={styles.viewport}></div>
+        </Col>
+        <Col span={12}>
+          {blobData && (
+            <>
+              <h2>blobData</h2>
+              <img key="blob" src={blobData} className={styles.preview} />
+            </>
+          )}
+          {base64Data && (
+            <>
+              <h2>base64Data</h2>
+              <img key="base64" src={base64Data} className={styles.preview} />
+            </>
+          )}
+        </Col>
+      </Row>
+    </Card>
+  )
+}

--- a/packages/extension/src/tools/snapshot/index.ts
+++ b/packages/extension/src/tools/snapshot/index.ts
@@ -74,9 +74,10 @@ export class Snapshot {
   }
 
   /* 下载图片 */
-  getSnapshot(fileName: string, backgroundColor: string) {
+  async getSnapshot(fileName: string, backgroundColor: string) {
     this.fileName = fileName || `logic-flow.${Date.now()}.png`
     const svg = this.getSvgRootElement(this.lf)
+    await updateImageSource(svg)
     this.getCanvasData(svg, backgroundColor).then(
       (canvas: HTMLCanvasElement) => {
         const imgURI = canvas
@@ -88,8 +89,9 @@ export class Snapshot {
   }
 
   /* 获取base64对象 */
-  getSnapshotBase64(backgroundColor: string) {
+  async getSnapshotBase64(backgroundColor: string) {
     const svg = this.getSvgRootElement(this.lf)
+    await updateImageSource(svg)
     return new Promise((resolve) => {
       this.getCanvasData(svg, backgroundColor).then(
         (canvas: HTMLCanvasElement) => {
@@ -106,8 +108,9 @@ export class Snapshot {
   }
 
   /* 获取Blob对象 */
-  getSnapshotBlob(backgroundColor: string) {
+  async getSnapshotBlob(backgroundColor: string) {
     const svg = this.getSvgRootElement(this.lf)
+    await updateImageSource(svg)
     return new Promise((resolve) => {
       this.getCanvasData(svg, backgroundColor).then(
         (canvas: HTMLCanvasElement) => {
@@ -273,3 +276,135 @@ export class Snapshot {
 }
 
 export default Snapshot
+
+/**
+ * 图片缓存, 已请求过的图片直接从缓存中获取
+ */
+const imageCache: Record<string, string> = {}
+
+/**
+ * 当获取图片失败时会返回失败信息，是 text/plain 类型的数据
+ * @param str - 图片内容
+ * @returns
+ */
+function isTextPlainBase64(str: string) {
+  return str.startsWith('data:text/plain')
+}
+
+/**
+ * 将网络图片转为 base64
+ * @param url - 图片地址
+ * @returns
+ */
+async function convertImageToBase64(url: string): Promise<string> {
+  if (imageCache[url]) {
+    return imageCache[url]
+  }
+  return new Promise((resolve, reject) => {
+    try {
+      fetch(url)
+        .then((response) => response.blob())
+        .then((blob) => {
+          const reader = new FileReader()
+          reader.onloadend = () => {
+            resolve((imageCache[url] = reader.result as string))
+          }
+          reader.onerror = reject
+          reader.readAsDataURL(blob)
+        })
+        .catch(() => {
+          resolve((imageCache[url] = url))
+        })
+    } catch (error) {
+      // 如果转换失败，后续大概率仍然会失败，因此直接缓存
+      return (imageCache[url] = url)
+    }
+  })
+}
+
+/**
+ * 使用 base64 的图片替换 img 标签的 src 或 image 标签的 href
+ * @param node - html 节点或 svg 节点
+ */
+async function updateImageSrcOrHrefWithBase64Image(
+  node: HTMLImageElement | SVGImageElement,
+  attrName: 'src' | 'href',
+) {
+  try {
+    const url = node.getAttribute(attrName) || ''
+    // 已经是 base64 图片，不需要处理
+    if (url.startsWith('data:')) {
+      return
+    }
+    const base64Image = await convertImageToBase64(url)
+    if (isTextPlainBase64(base64Image)) {
+      return
+    }
+    node.setAttribute(attrName, base64Image)
+  } catch (error) {
+    console.error(error)
+  }
+}
+
+/**
+ * 使用 base64 的图片替换背景图片
+ * @param node - html 节点
+ * @param styleAttr - 样式属性名称
+ */
+async function updateBackgroundImageWithBase64Image(
+  node: HTMLElement,
+  url: string,
+) {
+  try {
+    // 已经是 base64 图片，不需要处理
+    if (url.startsWith('data:')) {
+      return
+    }
+    const base64Image = await convertImageToBase64(url)
+    if (isTextPlainBase64(base64Image)) {
+      return
+    }
+    node.style.backgroundImage = `url(${base64Image})`
+  } catch (error) {
+    console.error(error)
+  }
+}
+
+/**
+ * 更新图片数据
+ * @param node - 节点
+ */
+async function updateImageSource(node: HTMLElement | SVGElement) {
+  const nodes = [node]
+  let nodePtr
+  const promises: any[] = []
+  while (nodes.length) {
+    nodePtr = nodes.shift()
+    if (nodePtr.children.length) {
+      nodes.push(...nodePtr.children)
+    }
+    if (nodePtr instanceof HTMLElement) {
+      // 如果有 style 的 background, backgroundImage 属性中有 url(xxx), 尝试替换为 base64 图片
+      const { background, backgroundImage } = nodePtr.style
+      const backgroundUrlMatch = background.match(/url\(["']?(.*?)["']?\)/)
+      if (backgroundUrlMatch && backgroundUrlMatch[1]) {
+        const imageUrl = backgroundUrlMatch[1]
+        promises.push(updateBackgroundImageWithBase64Image(nodePtr, imageUrl))
+      }
+      const backgroundImageUrlMatch = backgroundImage.match(
+        /url\(["']?(.*?)["']?\)/,
+      )
+      if (backgroundImageUrlMatch && backgroundImageUrlMatch[1]) {
+        const imageUrl = backgroundImageUrlMatch[1]
+        promises.push(updateBackgroundImageWithBase64Image(nodePtr, imageUrl))
+      }
+    }
+    // 如果有 img 和 image 标签，尝试将 src 和 href 替换为 base64 图片
+    if (nodePtr instanceof HTMLImageElement) {
+      promises.push(updateImageSrcOrHrefWithBase64Image(nodePtr, 'src'))
+    } else if (nodePtr instanceof SVGImageElement) {
+      promises.push(updateImageSrcOrHrefWithBase64Image(nodePtr, 'href'))
+    }
+  }
+  await Promise.all(promises)
+}


### PR DESCRIPTION
关联的 issue: https://github.com/didi/LogicFlow/issues/477 https://github.com/didi/LogicFlow/issues/1076
Snapshot 插件支持导出节点中的网络图片。
之前按照 issue 中的建议，使用 html2Canvas 和 dom-to-image 均无法正确导出节点中的图片。
在公司项目开发中通过在调用 getSnapshot() 之前将   标签的图片替换成 base64 字符串, 将 style 中的 background, background-image 替换成 base64 字符串, 可以正确导出节点中的图片。
测试范围覆盖了 getSnapshot, getSnapshotBase64, getSnapshotBlob, 均成功导出带有网络图片的节点。
![image](https://github.com/didi/LogicFlow/assets/37300913/93269e55-39ce-4042-9f9e-0b71ffdf2868)
