### PR TITLE
feat: snapshot插件小优化

### DIFF
--- a/examples/feature-examples/src/pages/extensions/snapshot/index.tsx
+++ b/examples/feature-examples/src/pages/extensions/snapshot/index.tsx
@@ -71,6 +71,7 @@ export default function SnapshotExample() {
   const [fileType, setFileType] = useState<string>('png') // 下载的图片类型
   const [width, setWidth] = useState<number>() // 宽度
   const [height, setHeight] = useState<number>() // 高度
+  const [backgroundColor, setBackgroundColor] = useState<string>('white') // 背景颜色
   const [padding, setPadding] = useState<number>() //padding
   const [quality, setQuality] = useState<number>() // 图片质量
   const [partial, setPartial] = useState<boolean>(true) // 导出局部渲染
@@ -133,7 +134,7 @@ export default function SnapshotExample() {
   const downLoad = () => {
     const params: ToImageOptions = {
       fileType,
-      backgroundColor: 'yellow',
+      backgroundColor,
       partial,
       width,
       height,
@@ -149,7 +150,7 @@ export default function SnapshotExample() {
     if (lfRef.current) {
       setBase64Data('')
       lfRef.current
-        .getSnapshotBlob('#fff', fileType)
+        .getSnapshotBlob(backgroundColor, fileType)
         .then(
           ({
             data,
@@ -172,7 +173,7 @@ export default function SnapshotExample() {
     if (lfRef.current) {
       setBlobData('')
       lfRef.current
-        .getSnapshotBase64('#fff')
+        .getSnapshotBase64(backgroundColor)
         .then(
           ({
             data,
@@ -265,6 +266,11 @@ export default function SnapshotExample() {
       </Space>
       <p></p>
       <Space>
+        <Input
+          addonBefore="背景颜色"
+          value={backgroundColor}
+          onChange={(e) => setBackgroundColor(e.target.value)}
+        />
         <InputNumber
           addonBefore="padding："
           value={padding}


### PR DESCRIPTION
- snapshot 插件注释丰富，cloneSvg 函数封装优化
- snapshot 的示例增加背景色控制

> 最近正好在看 Canvas 相关的东西，第一反应想到的就是 Snapshot 插件可能是基于 Canvas 实现的😄

---

https://github.com/didi/LogicFlow/blob/84cd725ba453006d75c365ddb790c302719825d6/packages/extension/src/tools/snapshot/index.ts#L258-L260

@FanSun521 cloneSvg 增加样式的方式是增加样式节点，会改变 copy.lastChild 的指向

明白了～

https://github.com/didi/LogicFlow/blob/84cd725ba453006d75c365ddb790c302719825d6/packages/extension/src/tools/snapshot/index.ts#L315-L317