### PR TITLE
fix(core&site): 修复自定义节点 Model 中 initNodeData 方法不生效

### DIFF
--- a/examples/feature-examples/src/components/nodes/custom-circle/index.ts
+++ b/examples/feature-examples/src/components/nodes/custom-circle/index.ts
@@ -1,0 +1,28 @@
+import LogicFlow, { CircleNode, CircleNodeModel } from '@logicflow/core'
+import NodeConfig = LogicFlow.NodeConfig
+
+class CustomCircleModel extends CircleNodeModel {
+  // constructor(data: any, graphModel: any) {
+  //   console.log('CustomCircleModel', 'constructor');
+  //   super(data, graphModel)
+  // }
+
+  initNodeData(data: NodeConfig) {
+    // console.log('CustomCircleModel', 'initNodeData', data);
+    super.initNodeData(data)
+    this.r = 60
+  }
+
+  // or
+  // setAttributes() {
+  //   console.log('CustomCircleModel', 'setAttributes');
+  //   this.r = 30;
+  //   console.log(this.r, 'r', this);
+  // }
+}
+
+export default {
+  type: 'customCircle',
+  view: CircleNode,
+  model: CustomCircleModel,
+}

--- a/examples/feature-examples/src/components/nodes/custom-diamond/index.tsx
+++ b/examples/feature-examples/src/components/nodes/custom-diamond/index.tsx
@@ -1,0 +1,27 @@
+import LogicFlow, { DiamondNode, DiamondNodeModel } from '@logicflow/core'
+import NodeConfig = LogicFlow.NodeConfig
+
+class CustomDiamondModel extends DiamondNodeModel {
+  // constructor(data: any, graphModel: any) {
+  //   console.log('CustomCircleModel', 'constructor');
+  //   super(data, graphModel)
+  // }
+
+  initNodeData(data: NodeConfig) {
+    super.initNodeData(data)
+    this.rx = 50
+    this.ry = 60
+  }
+
+  // or
+  // setAttributes() {
+  //  this.rx = 50
+  //  this.ry = 60
+  // }
+}
+
+export default {
+  type: 'customDiamond',
+  view: DiamondNode,
+  model: CustomDiamondModel,
+}

--- a/examples/feature-examples/src/components/nodes/custom-ellipse/index.tsx
+++ b/examples/feature-examples/src/components/nodes/custom-ellipse/index.tsx
@@ -18,15 +18,21 @@ export type CustomProperties = {
 class CustomEllipseNode extends EllipseNode {}
 
 class CustomEllipseNodeModel extends EllipseNodeModel {
-  setAttributes() {
-    const { rx, ry } = this.properties as CustomProperties
-    if (rx) {
-      this.rx = rx
-    }
-    if (ry) {
-      this.ry = ry
-    }
+  initNodeData(data: LogicFlow.NodeConfig): void {
+    super.initNodeData(data)
+    this.rx = 50
+    this.ry = 30
   }
+
+  // setAttributes() {
+  //   const { rx, ry } = this.properties as CustomProperties
+  //   if (rx) {
+  //     this.rx = rx
+  //   }
+  //   if (ry) {
+  //     this.ry = ry
+  //   }
+  // }
 
   getTextStyle(): LogicFlow.TextNodeTheme {
     // const { x, y, width, height } = this

--- a/examples/feature-examples/src/components/nodes/custom-polygon/index.tsx
+++ b/examples/feature-examples/src/components/nodes/custom-polygon/index.tsx
@@ -1,0 +1,29 @@
+import LogicFlow, { PolygonNode, PolygonNodeModel } from '@logicflow/core'
+import NodeConfig = LogicFlow.NodeConfig
+
+class CustomPolygonModel extends PolygonNodeModel {
+  // constructor(data: any, graphModel: any) {
+  //   super(data, graphModel)
+  // }
+
+  initNodeData(data: NodeConfig) {
+    super.initNodeData(data)
+    this.points = [
+      [0, 100],
+      [50, 25],
+      [50, 75],
+      [100, 0],
+    ] // 闪电
+  }
+
+  // or
+  // setAttributes() {
+  //   this.points = [[0,100], [50,25], [50,75], [100,0]] // 闪电
+  // }
+}
+
+export default {
+  type: 'customPolygon',
+  view: PolygonNode,
+  model: CustomPolygonModel,
+}

--- a/examples/feature-examples/src/components/nodes/custom-rect/index.tsx
+++ b/examples/feature-examples/src/components/nodes/custom-rect/index.tsx
@@ -19,6 +19,13 @@ export type CustomProperties = {
 class CustomRectNode extends RectNode {}
 
 class CustomRectNodeModel extends RectNodeModel {
+  // initNodeData(data: LogicFlow.NodeConfig): void {
+  //   super.initNodeData(data)
+  //   this.width = 100
+  //   this.height = 50
+  //   this.radius = 10
+  // }
+
   setAttributes() {
     console.log('this.properties', this.properties)
     const { width, height, radius } = this.properties as CustomProperties

--- a/examples/feature-examples/src/pages/graph/index.tsx
+++ b/examples/feature-examples/src/pages/graph/index.tsx
@@ -7,6 +7,12 @@ import { useEffect, useRef } from 'react'
 import { combine, square, star, uml, user } from './nodes'
 import { animation, connection } from './edges'
 
+import customCircle from '@/components/nodes/custom-circle'
+import customRect from '@/components/nodes/custom-rect'
+import customEllipse from '@/components/nodes/custom-ellipse'
+import customDiamond from '@/components/nodes/custom-diamond'
+import customPolygon from '@/components/nodes/custom-polygon'
+
 import GraphData = LogicFlow.GraphData
 import styles from './index.less'
 
@@ -120,6 +126,46 @@ const data = {
   ],
 }
 
+// const customData = {
+//   nodes: [
+//     {
+//       id: 'custom-circle',
+//       text: 'custom-circle',
+//       type: 'customCircle',
+//       x: 100,
+//       y: 100,
+//     },
+//     {
+//       id: 'custom-rect',
+//       text: 'custom-rect',
+//       type: 'customRect',
+//       x: 300,
+//       y: 100,
+//     },
+//     {
+//       id: 'custom-ellipse',
+//       text: 'custom-ellipse',
+//       type: 'customEllipse',
+//       x: 500,
+//       y: 100,
+//     },
+//     {
+//       id: 'custom-diamond',
+//       text: 'custom-diamond',
+//       type: 'customDiamond',
+//       x: 700,
+//       y: 100,
+//     },
+//     {
+//       id: 'custom-polygon',
+//       text: 'custom-polygon',
+//       type: 'customPolygon',
+//       x: 100,
+//       y: 300,
+//     },
+//   ]
+// }
+
 export default function BasicNode() {
   const lfRef = useRef<LogicFlow>()
   const containerRef = useRef<HTMLDivElement>(null)
@@ -135,6 +181,11 @@ export default function BasicNode() {
       star,
       uml,
       user,
+      customCircle,
+      customRect,
+      customEllipse,
+      customDiamond,
+      customPolygon,
     ]
 
     map(elements, (customElement) => {
@@ -221,6 +272,8 @@ export default function BasicNode() {
       registerEvents(lf)
 
       lf.render(data)
+      // lf.render(customData)
+
       lfRef.current = lf
       ;(window as any).lf = lf
     }

--- a/packages/core/src/model/node/CircleNodeModel.ts
+++ b/packages/core/src/model/node/CircleNodeModel.ts
@@ -37,6 +37,7 @@ export class CircleNodeModel<
     super(data, graphModel)
     // this.properties = data.properties || {}
 
+    this.initNodeData(data)
     this.setAttributes()
   }
 

--- a/packages/core/src/model/node/DiamondNodeModel.ts
+++ b/packages/core/src/model/node/DiamondNodeModel.ts
@@ -33,6 +33,7 @@ export class DiamondNodeModel<
     super(data, graphModel)
     // this.properties = data.properties || {}
 
+    this.initNodeData(data)
     this.setAttributes()
   }
 

--- a/packages/core/src/model/node/EllipseNodeModel.ts
+++ b/packages/core/src/model/node/EllipseNodeModel.ts
@@ -31,6 +31,7 @@ export class EllipseNodeModel<
     super(data, graphModel)
     // this.properties = data.properties || {}
 
+    this.initNodeData(data)
     this.setAttributes()
   }
 

--- a/packages/core/src/model/node/PolygonNodeModel.ts
+++ b/packages/core/src/model/node/PolygonNodeModel.ts
@@ -44,6 +44,7 @@ export class PolygonNodeModel<
     super(data, graphModel)
     // this.properties = data.properties || {}
 
+    this.initNodeData(data)
     this.setAttributes()
   }
 

--- a/packages/core/src/model/node/RectNodeModel.ts
+++ b/packages/core/src/model/node/RectNodeModel.ts
@@ -28,6 +28,7 @@ export class RectNodeModel<
     // TODO：类字段初始化会覆盖 super、setAttributes 中设置的属性
     // this.properties = data.properties || {}
     // TODO: bug here, 上面更新 properties 会触发 setAttributes，下面再主动调用，会导致触发两次
+    this.initNodeData(data)
     this.setAttributes()
   }
 

--- a/sites/docs/docs/tutorial/basic/node.en.md
+++ b/sites/docs/docs/tutorial/basic/node.en.md
@@ -38,7 +38,7 @@ nodes based on inheritance.
 
 LogicFlow implements custom nodes and edges based on inheritance. Developers can inherit the
 built-in nodes of LogicFlow and then use
-object-oriented [overriding](https://baike.baidu.com/item/%E9%87%8D%E5%86%99/9355942?fr=aladdin)
+object-oriented <a href="https://baike.baidu.com/item/%E9%87%8D%E5%86%99/9355942?fr=aladdin" target="_blanl">overriding</a> 
 mechanisms. By overriding methods related to node styles, developers can achieve the effect of
 customizing node styles.
 
@@ -101,7 +101,7 @@ class CustomNode extends RectResize.view {
 
 LogicFlow categorizes custom node appearance into two ways: `custom node style attribute`
 and `custom node shape attribute`. For more details on how to define them,
-see [NodeModelApi](../../api/nodeModel.en.md)。
+see [NodeModelApi](../../api/model/nodeModel.en.md)。
 
 #### 1. style attributes
 
@@ -113,7 +113,7 @@ redefining the theme based on the current node type.
 For example, if all `rect` nodes in the theme have their border color defined as red `stroke: red`,
 then you can redefine `UserTask` to have a blue `stroke: blue` border when customizing the
 node `UserTask`. For more granular node style control,
-see [API Style Attributes](../../api/nodeModel.en.md#style-attributes).
+see [API Style Attributes](../../api/model/nodeModel.en.md#style-attributes).
 
 ```tsx | pure
 class UserTaskModel extends RectNodeModel {
@@ -134,7 +134,7 @@ points for nodes and start/end points for connections based on them. Customizing
 requires modification within the `setAttributes` method or `initNodeData` method.
 
 LogicFlow has some shape attributes specific to each base node.
-See [API Shape Attributes](../../api/nodeModel.en.md#shape-attributes) for details.
+See [API Shape Attributes](../../api/model/nodeModel.en.md#shape-attributes) for details.
 
 ```tsx | pure
 class customRectModel extends RectNodeModel {
@@ -166,7 +166,7 @@ In the previous LogicFlow example, it was mentioned that both nodes and edges in
 retain a properties field. This field allows developers not only to modify elements' `styles`
 and `shapes`, but also to store their own `business` attributes. Therefore, when customizing node
 styles, developers can use properties from
-the [properties](../../api/nodeModel.en.md#data-attributes) to control how nodes display different
+the [properties](../../api/model/nodeModel.en.md#data-attributes) to control how nodes display different
 styles.
 
 <code id="custom-rect" src="../../../src/tutorial/basic/node/properties"></code>
@@ -174,7 +174,7 @@ styles.
 :::info
 
 If you don't understand why `this.properties` prints out as a Proxy object, you can't see the
-properties. Please check the [issue](https://github.com/didi/LogicFlow/issues/530), Printing a Proxy
+properties. Please check the <a href="https://github.com/didi/LogicFlow/issues/530" target="_blank">issue</a>, Printing a Proxy
 object using `{ ...this.properties }`.
 
 :::
@@ -191,7 +191,7 @@ The following is an example of a node `view`. Click `node1` several times to try
 
 Here the `h function` is used for the return of `Shape`. The `h` method is a rendering function
 exposed by LogicFlow, and its usage is the same as `react` and `vue`'
-s [createElement](https://cn.vuejs.org/v2/guide/render-function.html#createElement-%E5%8F%82%E6%95%B0).
+s <a href="https://v2.vuejs.org/v2/guide/render-function#createElement-Arguments" target="_blank">createElement</a> .
 But here we need to create `svg` tags, so some basic knowledge of svg is required.
 
 To give a few simple examples.
@@ -318,7 +318,7 @@ h("polygon", {
 :::info{title=Customize the view of the rectangle with the radius setting.}
 In `model`, `radius` is the shape attribute of the rectangle node. But when customizing `view`, you
 need to note that svg doesn't use `radius` to set the rounded corners of the rectangle,
-but [rx](https://developer.mozilla.org/zh-CN/docs/Web/SVG/Attribute/rx), ry. So when
+but <a href="https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/rx" target="_blank">rx</a>, ry. So when
 customizing `view`'s rectangle, you need to assign the value of `radius` in the model to `rx`
 and `ry`. you need to assign `radius` to `rx` and `ry` in the model when customizing the rectangle
 of `view`, otherwise the rounded corners won't take effect.
@@ -331,18 +331,18 @@ passed from the parent component through `this.props`. The `this.props` object c
 properties, they are.
 
 - `model`: represents the model of the custom node
-- [graphModel](../../api/graphModel.en.md): the model for the entire graph of logicflow
+- [graphModel](../../api/model/graphModel.en.md): the model for the entire graph of logicflow
 
 ##### 3. How to get the path of an icon?
 
-Generally, for icons we can look for the UI or go to [iconfont.co.uk](https://www.iconfont.cn/) to
+Generally, for icons we can look for the UI or go to <a href="https://www.iconfont.cn/?lang=en-us" target="_blank">iconfont.co.uk</a> to
 get a file in svg format. Then open it as text in IDE and format it to see the code. The code is
 usually an outermost svg tag with one or more paths inside. at this point, we can just use the `h`
 method mentioned earlier to implement the code in the svg file.
 
 The svg tag typically includes the following attributes:
 
-- `viewBox`: The [viewBox](https://developer.mozilla.org/zh-CN/docs/Web/SVG/Attribute/viewBox)
+- `viewBox`: The <a href="https://developer.mozilla.org/zh-CN/docs/Web/SVG/Attribute/viewBox" target="_blank">viewBox</a>
   attribute allows a given set of graphic stretches to be specified to fit a particular container
   element. It is generally sufficient to copy the value of the `viewBox` attribute from the svg tag.
 - `width` and `height`: This doesn't need to use the `width` and `height` on the svg tag, just write

--- a/sites/docs/docs/tutorial/basic/node.zh.md
+++ b/sites/docs/docs/tutorial/basic/node.zh.md
@@ -18,8 +18,8 @@ LogicFlow是基于svg做的流程图编辑框架，所以我们的节点和连�
 2. 圆形 --- <a href="https://developer.mozilla.org/zh-CN/docs/Web/SVG/Element/circle" target="_blank">circle</a>
 3. 椭圆 --- <a href="https://developer.mozilla.org/zh-CN/docs/Web/SVG/Element/ellipse" target="_blank">ellipse</a>
 4. 多边形 --- <a href="https://developer.mozilla.org/zh-CN/docs/Web/SVG/Element/polygon" target="_blank">polygon</a>
-5. 文本 --- <a href="https://developer.mozilla.org/zh-CN/docs/Web/SVG/Element/text" target="_blank">text</a>
-6. 菱形 --- `diamond`
+5. 菱形 --- `diamond`
+6. 文本 --- <a href="https://developer.mozilla.org/zh-CN/docs/Web/SVG/Element/text" target="_blank">text</a>
 7. HTML --- `html`
 
 <code id="node-shapes" src="../../../src/tutorial/basic/node/shapes"></code>
@@ -74,7 +74,7 @@ class CustomNode extends RectResize.view {}
 ### 自定义节点`model`
 
 LogicFlow把自定义节点外观分为了`自定义节点样式属性`和`自定义节点形状属性`
-两种方式。更多详细定义方法，请查看[NodeModelApi](../../api/nodeModel.zh.md)。
+两种方式。更多详细定义方法，请查看[NodeModel](../../api/model/nodeModel.zh.md)。
 
 #### 1. 样式属性
 
@@ -84,7 +84,7 @@ LogicFlow把自定义节点外观分为了`自定义节点样式属性`和`自�
 
 例如：在主题中对所有`rect`节点都定义其边框颜色为红色`stroke: red`，那么可以在自定义节点`UserTask`
 的时候，重新定义`UserTask`边框为蓝色`stroke: blue`
-。更细粒度的节点样式控制方法，详情见[API 样式属性](../../api/nodeModel.zh.md#样式属性)。
+。更细粒度的节点样式控制方法，详情见[API 样式属性](../../api/model/nodeModel.zh.md#样式属性)。
 
 ```tsx | pure
 class UserTaskModel extends RectNodeModel {
@@ -103,7 +103,7 @@ class UserTaskModel extends RectNodeModel {
 等这些控制着节点最终形状的属性。因为LogicFlow在计算节点的锚点、连线的起点终点的时候，会基于形状属性进行计算。对于形状属性的自定义，需要在`setAttributes`
 方法或`initNodeData`方法中进行。
 
-LogicFlow对于不同的基础节点，存在一些各基础节点自己特有的形状属性。详情见[API 形状属性](../../api/nodeModel.zh.md#形状属性)。
+LogicFlow对于不同的基础节点，存在一些各基础节点自己特有的形状属性。详情见[API 形状属性](../../api/model/nodeModel.zh.md#形状属性)。
 
 ```tsx | pure
 class customRectModel extends RectNodeModel {
@@ -134,7 +134,7 @@ class customRectModel extends RectNodeModel {
 在上一节LogicFlow的实例中的`图数据`
 里提到，不论是节点还是边，LogicFlow都保留了properties字段，不仅可以修改元素的`样式`、`形状`
 属性，可以用于给开发者存放自己的`业务`
-属性。所以在自定义节点样式的时候，可以基于[properties](../../api/nodeModel.zh.md#数据属性)
+属性。所以在自定义节点样式的时候，可以基于 [properties](../../api/model/nodeModel.zh.md#数据属性) 
 中的属性来控制节点显示不同的样式。
 
 <code id="custom-rect" src="../../../src/tutorial/basic/node/properties"></code>
@@ -142,7 +142,7 @@ class customRectModel extends RectNodeModel {
 :::info{title=提示}
 
 如果不了解为什么`this.properties`打印出来是一个Proxy对象,
-无法看到属性。请查看[issue](https://github.com/didi/LogicFlow/issues/530),
+无法看到属性。请查看 <a href="https://github.com/didi/LogicFlow/issues/530" target="_blank">issue</a> ,
 可以使用`{ ...this.properties }`打印Proxy对象。
 
 :::
@@ -158,8 +158,8 @@ LogicFlow在自定义节点的`model`
 <code id="node-custom-view" src="../../../src/tutorial/basic/node/custom-view"></code>
 
 这里对于`getShape`的方法返回用到了`h函数`，`h`函数是LogicFlow对外暴露的渲染函数，其用法与`react`、`vue`
-的[createElement](https://cn.vuejs.org/v2/guide/render-function.html#createElement-%E5%8F%82%E6%95%B0)
-一致。但是这里我们需要创建的是`svg`标签，所以需要有一定的svg基础知识。
+的 <a href="https://v2.cn.vuejs.org/v2/guide/render-function.html#createElement-%E5%8F%82%E6%95%B0" target="_blank">createElement</a> 
+一致。但是这里我们需要创建的是 `svg` 标签，所以需要有一定的 `svg` 基础知识。
 
 举几个简单的例子:
 
@@ -275,7 +275,7 @@ h('polygon', {
 :::info{title=自定义矩形的view时radius设置}
 在`model`中，`radius`是矩形节点的形状属性。但是在自定义`view`
 时需要注意，svg里面设置矩形的圆角并不是用`radius`
-，而是使用[rx](https://developer.mozilla.org/zh-CN/docs/Web/SVG/Attribute/rx), ry。所以在自定义`view`
+，而是使用 <a href="https://developer.mozilla.org/zh-CN/docs/Web/SVG/Attribute/rx" target="_blank">rx</a> , ry。所以在自定义`view`
 的矩形时，需要将model中`radius`的赋值给`rx`和`ry`，否则圆角将不生效。
 :::
 
@@ -285,17 +285,17 @@ LogicFlow是基于`preact`开发的，我们自定义节点view的时候，可�
 获取父组件传递过来的数据。`this.props`对象包含两个属性，分别为:
 
 - `model`: 表示自定义节点的model
-- [graphModel](../../api/graphModel.zh.md): 表示logicflow整个图的model
+- [graphModel](../../api/model/graphModel.zh.md): 表示logicflow整个图的model
 
 ##### 3. 图标的path如何获取？
 
-一般情况下，图标我们可以找UI或者去[iconfont.cn](https://www.iconfont.cn/)
+一般情况下，图标我们可以找UI或者去 <a href="https://www.iconfont.cn/" target="_blank">iconfont.cn</a> 
 获得一个svg格式的文件。然后再IDE中以文本的方式打开，然后格式化，就可以看到代码。代码中一般是最外层一个svg标签，里面是一个或者多个path。这个时候，我们使用前面提到的`h`
 方法来实现svg文件中的代码即可。
 
 svg标签一般包括如下属性：
 
-- `viewBox`: [viewBox](https://developer.mozilla.org/zh-CN/docs/Web/SVG/Attribute/viewBox)
+- `viewBox`: <a href="https://developer.mozilla.org/zh-CN/docs/Web/SVG/Attribute/viewBox" target="_blank">viewBox</a>
   属性允许指定一个给定的一组图形伸展以适应特定的容器元素。一般把svg标签上的`viewBox`属性值复制过来就行。
 - `width`和`height`: 这个不需要使用svg标签上的`width`和`height`, 直接写成你期望的宽高就行。
 


### PR DESCRIPTION
- 修复circle、diamond、polygon、rect、ellipse 中 initNodeData 方法不生效 #1775 
- 修复官网教程- 基础教程- 节点文章中跳转错误
- example中补充自定义circle、diamon、polygon节点