### PR TITLE
fix(build): 修正 build:watch 脚本中的命令格式

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
     "build:umd": "pnpm run --if-present build:less && rollup -c ../../rollup.config.js --bundleConfigAsCjs",
     "build:dev": "pnpm run --if-present build:less && run-p -s build:cjs build:esm",
     "build:watch": "run-p -s build:less build:watch:esm build:watch:cjs",
-    "build:watch:esm": "run-s -s 'build:esm -w'",
-    "build:watch:cjs": "run-s -s 'build:cjs -w'",
+    "build:watch:esm": "run-s -s  \"build:esm -w\"",
+    "build:watch:cjs": "run-s -s  \"build:cjs -w\"",
     "build": "run-p -s build:dev build:umd",
     "prebuild": "run-s -s clean:build"
   },


### PR DESCRIPTION
在 build:watch:esm 和 build:watch:cjs 脚本中添加反斜杠，
以确保命令在各种环境中正确执行。这个修改提高了构建过程的可靠性和跨平台兼容性。
![image](https://github.com/user-attachments/assets/d6c678a0-b884-4b1b-8908-fa08e6289b2a)


Closes #1818