### PR TITLE
fix(core): node => rotate+正常模式resize(#1428)

### DIFF
--- a/examples/feature-examples/src/pages/graph/index.tsx
+++ b/examples/feature-examples/src/pages/graph/index.tsx
@@ -551,6 +551,20 @@ export default function BasicNode() {
         >
           删除节点
         </Button>
+        <Button
+          type="primary"
+          onClick={() => {
+            if (lfRef.current) {
+              const graphData = lfRef.current?.getEditConfig()
+              const { allowResize } = graphData
+              lfRef.current.updateEditConfig({
+                allowResize: !allowResize,
+              })
+            }
+          }}
+        >
+          切换allowResize
+        </Button>
       </Flex>
       <Divider orientation="left" orientationMargin="5" plain>
         节点面板

--- a/packages/core/src/algorithm/rotate.ts
+++ b/packages/core/src/algorithm/rotate.ts
@@ -1,0 +1,55 @@
+export interface SimplePoint {
+  x: number
+  y: number
+}
+
+/**
+ * 根据两个点获取中心点坐标
+ */
+export function getNewCenter(startPoint: SimplePoint, endPoint: SimplePoint) {
+  const { x: x1, y: y1 } = startPoint
+  const { x: x2, y: y2 } = endPoint
+  const newCenter = {
+    x: x1 + (x2 - x1) / 2,
+    y: y1 + (y2 - y1) / 2,
+  }
+  return newCenter
+}
+
+/**
+ * 旋转矩阵公式，可以获取某一个坐标旋转angle后的坐标
+ * @param p 当前坐标
+ * @param center 旋转中心
+ * @param angle 旋转角度（不是弧度）
+ */
+export function calculatePointAfterRotateAngle(
+  p: SimplePoint,
+  center: SimplePoint,
+  angle: number,
+) {
+  const radian = angleToRadian(angle)
+  const dx = p.x - center.x
+  const dy = p.y - center.y
+  const x = dx * Math.cos(radian) - dy * Math.sin(radian) + center.x
+  const y = dx * Math.sin(radian) + dy * Math.cos(radian) + center.y
+  return {
+    x,
+    y,
+  }
+}
+
+/**
+ * 角度转弧度
+ * @param angle 角度
+ */
+export function angleToRadian(angle: number) {
+  return (angle * Math.PI) / 180
+}
+
+/**
+ * 弧度转角度
+ * @param radian 弧度
+ */
+export function radianToAngle(radian: number) {
+  return (radian / Math.PI) * 180
+}

--- a/packages/core/src/model/node/BaseNodeModel.ts
+++ b/packages/core/src/model/node/BaseNodeModel.ts
@@ -699,6 +699,10 @@ export class BaseNodeModel<P extends PropertiesType = PropertiesType>
       this.y = this.y + deltaY
       this.text && this.moveText(0, deltaY)
     }
+    if (isAllowMoveX || isAllowMoveY) {
+      // 更新x和y的同时也要更新对应的transform旋转矩阵（依赖x、y)
+      this.rotate = this._rotate
+    }
     return isAllowMoveX || isAllowMoveY
   }
 

--- a/packages/core/src/util/resize.ts
+++ b/packages/core/src/util/resize.ts
@@ -85,8 +85,8 @@ export const recalcResizeInfo = (
   freezeWidth = false,
   freezeHeight = false,
   rotate = 0,
-  anchorX: number,
-  anchorY: number,
+  anchorX: number | undefined,
+  anchorY: number | undefined,
   oldCenterX: number,
   oldCenterY: number,
 ): ResizeInfo => {
@@ -169,8 +169,11 @@ export const recalcResizeInfo = (
     }
     return nextResizeInfo
   }
-
-  if (rotate % (2 * Math.PI) !== 0) {
+  if (
+    rotate % (2 * Math.PI) !== 0 &&
+    anchorX !== undefined &&
+    anchorY !== undefined
+  ) {
     // 角度rotate不为0，则触发另外的计算修正resize的deltaX和deltaY
     // 因为rotate不为0的时候，左上角的坐标一直在变化
     // 角度rotate不为0得到的resizeInfo.deltaX仅仅代表中心点的变化，而不是宽度的变化
@@ -280,17 +283,21 @@ export const triggerResizeEvent = (
 }
 
 // TODO：确认 handleResize 函数的类型定义
-// export type IHandleResizeParams = {
-//   deltaX: number
-//   deltaY: number
-//   index: ResizeControlIndex
-//   nodeModel: BaseNodeModel
-//   graphModel: GraphModel
-//   cancelCallback?: () => void
-// }
+export type IHandleResizeParams = {
+  x?: number
+  y?: number
+  deltaX: number
+  deltaY: number
+  index: ResizeControlIndex
+  nodeModel: BaseNodeModel
+  graphModel: GraphModel
+  cancelCallback?: () => void
+}
 
 /**
  * 处理节点的 resize 事件，提出来放到 utils 中，方便在外面（extension）中使用
+ * @param x
+ * @param y
  * @param deltaX
  * @param deltaY
  * @param index
@@ -307,7 +314,7 @@ export const handleResize = ({
   nodeModel,
   graphModel,
   cancelCallback,
-}) => {
+}: IHandleResizeParams) => {
   const {
     r, // circle
     rx, // ellipse/diamond
@@ -362,7 +369,12 @@ export const handleResize = ({
     cancelCallback?.()
     return
   }
-  if (rotate % (2 * Math.PI) == 0 || PCTResizeInfo) {
+  if (
+    rotate % (2 * Math.PI) == 0 ||
+    PCTResizeInfo ||
+    anchorX === undefined ||
+    anchorY === undefined
+  ) {
     // rotate!==0并且不是PCTResizeInfo时，即使是isFreezeWidth||isFreezeHeight
     // recalcRotatedResizeInfo()计算出来的中心点会发生变化
 

--- a/packages/core/src/util/resize.ts
+++ b/packages/core/src/util/resize.ts
@@ -16,33 +16,33 @@ function recalcRotatedResizeInfo(
   pct: number,
   resizeInfo: ResizeInfo,
   rotate: number,
-  anchorX: number,
-  anchorY: number,
+  controlX: number,
+  controlY: number,
   oldCenterX: number,
   oldCenterY: number,
   freezeWidth = false,
   freezeHeight = false,
 ) {
-  // 假设我们触摸的点是右下角的anchor
+  // 假设我们触摸的点是右下角的control
   const { deltaX, deltaY, width: oldWidth, height: oldHeight } = resizeInfo
   const angle = radianToAngle(rotate)
 
-  // 右下角的anchor
-  const startZeroTouchAnchorPoint = {
-    x: anchorX, // control锚点的坐标x
-    y: anchorY, // control锚点的坐标y
+  // 右下角的control
+  const startZeroTouchControlPoint = {
+    x: controlX, // control锚点的坐标x
+    y: controlY, // control锚点的坐标y
   }
   const oldCenter = { x: oldCenterX, y: oldCenterY }
-  // 右下角的anchor坐标（transform后的-touchStartPoint）
-  const startRotatedTouchAnchorPoint = calculatePointAfterRotateAngle(
-    startZeroTouchAnchorPoint,
+  // 右下角的control坐标（transform后的-touchStartPoint）
+  const startRotatedTouchControlPoint = calculatePointAfterRotateAngle(
+    startZeroTouchControlPoint,
     oldCenter,
     angle,
   )
-  // 右下角的anchor坐标（transform后的-touchEndPoint）
-  const endRotatedTouchAnchorPoint = {
-    x: startRotatedTouchAnchorPoint.x + deltaX,
-    y: startRotatedTouchAnchorPoint.y + deltaY,
+  // 右下角的control坐标（transform后的-touchEndPoint）
+  const endRotatedTouchControlPoint = {
+    x: startRotatedTouchControlPoint.x + deltaX,
+    y: startRotatedTouchControlPoint.y + deltaY,
   }
   // 计算出新的宽度和高度以及新的中心点
   const {
@@ -50,8 +50,8 @@ function recalcRotatedResizeInfo(
     height: newHeight,
     center: newCenter,
   } = calculateWidthAndHeight(
-    startRotatedTouchAnchorPoint,
-    endRotatedTouchAnchorPoint,
+    startRotatedTouchControlPoint,
+    endRotatedTouchControlPoint,
     oldCenter,
     angle,
     freezeWidth,
@@ -85,8 +85,8 @@ export const recalcResizeInfo = (
   freezeWidth = false,
   freezeHeight = false,
   rotate = 0,
-  anchorX: number | undefined,
-  anchorY: number | undefined,
+  controlX: number | undefined,
+  controlY: number | undefined,
   oldCenterX: number,
   oldCenterY: number,
 ): ResizeInfo => {
@@ -171,8 +171,8 @@ export const recalcResizeInfo = (
   }
   if (
     rotate % (2 * Math.PI) !== 0 &&
-    anchorX !== undefined &&
-    anchorY !== undefined
+    controlX !== undefined &&
+    controlY !== undefined
   ) {
     // 角度rotate不为0，则触发另外的计算修正resize的deltaX和deltaY
     // 因为rotate不为0的时候，左上角的坐标一直在变化
@@ -181,8 +181,8 @@ export const recalcResizeInfo = (
       pct,
       nextResizeInfo,
       rotate,
-      anchorX,
-      anchorY,
+      controlX,
+      controlY,
       oldCenterX,
       oldCenterY,
       freezeWidth,
@@ -343,8 +343,8 @@ export const handleResize = ({
   }
 
   const pct = r || (rx && ry) ? 1 / 2 : 1
-  const anchorX = x
-  const anchorY = y
+  const controlX = x
+  const controlY = y
   const nextSize = recalcResizeInfo(
     index,
     resizeInfo,
@@ -352,8 +352,8 @@ export const handleResize = ({
     isFreezeWidth,
     isFreezeHeight,
     rotate,
-    anchorX,
-    anchorY,
+    controlX,
+    controlY,
     oldCenterX,
     oldCenterY,
   )
@@ -372,8 +372,8 @@ export const handleResize = ({
   if (
     rotate % (2 * Math.PI) == 0 ||
     PCTResizeInfo ||
-    anchorX === undefined ||
-    anchorY === undefined
+    controlX === undefined ||
+    controlY === undefined
   ) {
     // rotate!==0并且不是PCTResizeInfo时，即使是isFreezeWidth||isFreezeHeight
     // recalcRotatedResizeInfo()计算出来的中心点会发生变化
@@ -401,8 +401,8 @@ export const handleResize = ({
 }
 
 export function calculateWidthAndHeight(
-  startRotatedTouchAnchorPoint: SimplePoint,
-  endRotatedTouchAnchorPoint: SimplePoint,
+  startRotatedTouchControlPoint: SimplePoint,
+  endRotatedTouchControlPoint: SimplePoint,
   oldCenter: SimplePoint,
   angle: number,
   freezeWidth = false,
@@ -410,18 +410,18 @@ export function calculateWidthAndHeight(
   oldWidth: number,
   oldHeight: number,
 ) {
-  // 假设目前触摸的是右下角的anchor
-  // 计算出来左上角的anchor坐标，resize过程左上角的anchor坐标保持不变
+  // 假设目前触摸的是右下角的control点
+  // 计算出来左上角的control坐标，resize过程左上角的control坐标保持不变
   const freezePoint: SimplePoint = {
-    x: oldCenter.x - (startRotatedTouchAnchorPoint.x - oldCenter.x),
-    y: oldCenter.y - (startRotatedTouchAnchorPoint.y - oldCenter.y),
+    x: oldCenter.x - (startRotatedTouchControlPoint.x - oldCenter.x),
+    y: oldCenter.y - (startRotatedTouchControlPoint.y - oldCenter.y),
   }
   // 【touchEndPoint】右下角 + freezePoint左上角 计算出新的中心点
-  let newCenter = getNewCenter(freezePoint, endRotatedTouchAnchorPoint)
+  let newCenter = getNewCenter(freezePoint, endRotatedTouchControlPoint)
 
   // 得到【touchEndPoint】右下角-没有transform的坐标
-  let endZeroTouchAnchorPoint: SimplePoint = calculatePointAfterRotateAngle(
-    endRotatedTouchAnchorPoint,
+  let endZeroTouchControlPoint: SimplePoint = calculatePointAfterRotateAngle(
+    endRotatedTouchControlPoint,
     newCenter,
     -angle,
   )
@@ -436,13 +436,13 @@ export function calculateWidthAndHeight(
   )
 
   if (freezeWidth) {
-    // 如果固定width，那么不能单纯使用endZeroTouchAnchorPoint.x=startZeroTouchAnchorPoint.x
+    // 如果固定width，那么不能单纯使用endZeroTouchControlPoint.x=startZeroTouchControlPoint.x
     // 因为去掉transform的左上角不一定是重合的，我们要保证的是transform后的左上角重合
-    const newWidth = Math.abs(endZeroTouchAnchorPoint.x - zeroFreezePoint.x)
+    const newWidth = Math.abs(endZeroTouchControlPoint.x - zeroFreezePoint.x)
     const widthDx = newWidth - oldWidth
 
     // 点击的是左边锚点，是+widthDx/2，点击是右边锚点，是-widthDx/2
-    if (newCenter.x > endZeroTouchAnchorPoint.x) {
+    if (newCenter.x > endZeroTouchControlPoint.x) {
       // 当前触摸的是左边锚点
       newCenter.x = newCenter.x + widthDx / 2
     } else {
@@ -451,9 +451,9 @@ export function calculateWidthAndHeight(
     }
   }
   if (freezeHeight) {
-    const newHeight = Math.abs(endZeroTouchAnchorPoint.y - zeroFreezePoint.y)
+    const newHeight = Math.abs(endZeroTouchControlPoint.y - zeroFreezePoint.y)
     const heightDy = newHeight - oldHeight
-    if (newCenter.y > endZeroTouchAnchorPoint.y) {
+    if (newCenter.y > endZeroTouchControlPoint.y) {
       // 当前触摸的是上边锚点
       newCenter.y = newCenter.y + heightDy / 2
     } else {
@@ -482,15 +482,15 @@ export function calculateWidthAndHeight(
       newCenter,
       -angle,
     )
-    endZeroTouchAnchorPoint = {
+    endZeroTouchControlPoint = {
       x: newCenter.x - (zeroFreezePoint.x - newCenter.x),
       y: newCenter.y - (zeroFreezePoint.y - newCenter.y),
     }
   }
 
   // transform之前的坐标的左上角+右下角计算出宽度和高度
-  let width = Math.abs(endZeroTouchAnchorPoint.x - zeroFreezePoint.x)
-  let height = Math.abs(endZeroTouchAnchorPoint.y - zeroFreezePoint.y)
+  let width = Math.abs(endZeroTouchControlPoint.x - zeroFreezePoint.x)
+  let height = Math.abs(endZeroTouchControlPoint.y - zeroFreezePoint.y)
 
   // ---------- 使用transform之前的坐标计算出新的width和height ----------
 

--- a/packages/core/src/view/Control.tsx
+++ b/packages/core/src/view/Control.tsx
@@ -56,6 +56,10 @@ export class ResizeControl extends Component<
     })
   }
 
+  componentWillUnmount() {
+    this.dragHandler.cancelDrag()
+  }
+
   updateEdgePointByAnchors = () => {
     // https://github.com/didi/LogicFlow/issues/807
     // https://github.com/didi/LogicFlow/issues/875
@@ -241,10 +245,12 @@ export class ResizeControl extends Component<
 
   resizeNode = ({ deltaX, deltaY }: VectorData) => {
     const { index } = this
-    const { model, graphModel } = this.props
+    const { model, graphModel, x, y } = this.props
 
     // DONE: 调用每个节点中更新缩放时的方法 updateNode 函数，用来各节点缩放的方法
     handleResize({
+      x,
+      y,
       deltaX,
       deltaY,
       index,


### PR DESCRIPTION
related: [transform相关问题汇总](https://github.com/didi/LogicFlow/issues/1446)
fix: [https://github.com/didi/LogicFlow/issues/1428](https://github.com/didi/LogicFlow/issues/1428)
fix: [https://github.com/didi/LogicFlow/issues/1628](https://github.com/didi/LogicFlow/issues/1628)
fix: [https://github.com/didi/LogicFlow/issues/1813](https://github.com/didi/LogicFlow/issues/1813)
fix: [https://github.com/didi/LogicFlow/issues/1475](https://github.com/didi/LogicFlow/issues/1475)

## 1. 前言

node 加入`rotate`后，可能影响的范围有：

1. rotate + resize=>正常 resize 模式
2. rotate + resize=>等比例 resize 模式
3. rotate + bbox 调整 => 涉及到旋转后辅助线对齐
4. rotate + bbox 调整 => 涉及到点是否在某个旋转图形内的判断
5. rotate + bbox 调整 => 涉及到 anchor 与 anchor 连线的计算

---

本次 pr 主要针对 rotate + resize 的正常 resize 模式进行修复

1. [x] rotate + resize=>正常 resize 模式

注：由于失误，将control坐标的名称叫成anchorX和anchorY，代码中已经更改，但是这里的pr描述由于篇幅过长，重做比较耗费时间，因此这里没有更改，凡是出现anchor相关单词，都可以替换为control

## 2.问题发生的原因

在`rotate=0`的情况下，坐标转换简单，通过触摸点计算出 dx 和 dy，然后进行整体的 resize，但是在`rotate不等于0`的情况下，我们通过触摸点计算出 dx 和 dy 还得经过一层转化才能正确 resize

- 而目前代码中还是延续`rotate=0`的处理，也就是触摸点计算出来的 dx 和 dy 就是实际宽度和高度变化的 dx 和 dy，然后计算出`newWidth = oldWidth+dx`
- 同时，在 resize 过程中，我们一般会保持对角 anchor 的坐标不变化（在`rotate=0`的情况下拉伸右下角的 anchor，左上角 anchor 保持不变），而由于宽度和高度发生变化，因此中心点 center 也发生变化，因此左上角的 anchor 实际坐标会发生变化，因此这个时候不能简单使用`newCenter.x = oldCenter.x + dx`的逻辑

因此在`rotate不等于0`的情况下，`newWidth`的计算和`newCenter`的计算都需要进行调整

![问题发生的原因 (1)](https://github.com/user-attachments/assets/9ffef3aa-ca49-46bf-838a-a11e9c438cc2)

## 3.解决方法

在原来逻辑中，`recalcResizeInfo`先处理了`PCTResizeInfo`的情况（也就是等比例缩放），返回`nextResizeInfo`，然后再处理正常模式下缩放，返回`nextResizeInfo`

```js
export const recalcResizeInfo = () => {
  const nextResizeInfo = cloneDeep(resizeInfo);
  let { deltaX, deltaY } = nextResizeInfo;
  const { width, height, PCTResizeInfo } = nextResizeInfo;
  if (PCTResizeInfo) {
    //...处理
    return nextResizeInfo;
  }

  //...处理PCTResizeInfo为空的情况

  return nextResizeInfo;
};
```

因此我们在原来的逻辑上增加`PCTResizeInfo为空`并且`rotate不等于0`的逻辑处理: `recalcRotatedResizeInfo()`，不影响原来`等比例缩放`和`正常模式缩放+rotate=0`的处理逻辑

```js
export const recalcResizeInfo = () => {
  const nextResizeInfo = cloneDeep(resizeInfo);
  let { deltaX, deltaY } = nextResizeInfo;
  const { width, height, PCTResizeInfo } = nextResizeInfo;
  if (PCTResizeInfo) {
    //...处理等比例缩放的情况
    return nextResizeInfo;
  }

  if (rotate % (2 * Math.PI) !== 0) {
    return recalcRotatedResizeInfo(...);
  }

  //...处理PCTResizeInfo为空 + rotate等于0的情况

  return nextResizeInfo;
};
```

`recalcRotatedResizeInfo()`主要是

- 进行数据的拼接准备
- 通过核心方法`calculateWidthAndHeight()`计算出宽度、高度和新的中心点`newCenter`
- 然后我们就可以通过`newCenter`和`oldCenter`的比较得出`deltaX`和`deltaY`，因为最终我们是通过`BaseNodeModel.resize()`来重置 width、height，以及通过`BaseNodeModel.move()`的`this.x = this.x+deltaX`来更新中心点的坐标

```ts
function recalcRotatedResizeInfo(
  pct: number,
  resizeInfo: ResizeInfo,
  rotate: number,
  anchorX: number,
  anchorY: number,
  oldCenterX: number,
  oldCenterY: number,
  freezeWidth = false,
  freezeHeight = false
) {
  // 假设我们触摸的点是右下角的anchor
  const { deltaX, deltaY, width: oldWidth, height: oldHeight } = resizeInfo;
  const angle = radianToAngle(rotate);

  // 右下角的anchor
  const startZeroTouchAnchorPoint = {
    x: anchorX, // control锚点的坐标x
    y: anchorY, // control锚点的坐标y
  };
  const oldCenter = { x: oldCenterX, y: oldCenterY };
  // 右下角的anchor坐标（transform后的-touchStartPoint）
  const startRotatedTouchAnchorPoint = calculatePointAfterRotateAngle(
    startZeroTouchAnchorPoint,
    oldCenter,
    angle
  );
  // 右下角的anchor坐标（transform后的-touchEndPoint）
  const endRotatedTouchAnchorPoint = {
    x: startRotatedTouchAnchorPoint.x + deltaX,
    y: startRotatedTouchAnchorPoint.y + deltaY,
  };
  // 通过固定点、旧的中心点、触摸点、旋转角度计算出新的宽度和高度以及新的中心点
  const {
    width: newWidth,
    height: newHeight,
    center: newCenter,
  } = calculateWidthAndHeight(
    startRotatedTouchAnchorPoint,
    endRotatedTouchAnchorPoint,
    oldCenter,
    angle,
    freezeWidth,
    freezeHeight,
    oldWidth,
    oldHeight
  );
  // handleResize()会处理isFreezeWidth和deltaX、isFreezeHeight和deltaY，这里不再处理
  resizeInfo.width = newWidth * pct;
  resizeInfo.height = newHeight * pct;

  // BaseNodeModel.resize(deltaX/2, deltaY/2)，因此这里要*2
  resizeInfo.deltaX = (newCenter.x - oldCenter.x) * 2;
  resizeInfo.deltaY = (newCenter.y - oldCenter.y) * 2;

  return resizeInfo;
}
```

如下面代码所示，当我们不考虑`freezeWidth`和`freezeHeight`时，代码逻辑是非常简单的

> 下面将通过图示进行思路的讲解

```ts
export function calculateWidthAndHeight(
  startRotatedTouchAnchorPoint: SimplePoint,
  endRotatedTouchAnchorPoint: SimplePoint,
  oldCenter: SimplePoint,
  angle: number,
  freezeWidth = false,
  freezeHeight = false,
  oldWidth: number,
  oldHeight: number
) {
  // 假设目前触摸的是右下角的anchor
  // 计算出来左上角的anchor坐标，resize过程左上角的anchor坐标保持不变
  const freezePoint: SimplePoint = {
    x: oldCenter.x - (startRotatedTouchAnchorPoint.x - oldCenter.x),
    y: oldCenter.y - (startRotatedTouchAnchorPoint.y - oldCenter.y),
  };
  // 【touchEndPoint】右下角 + freezePoint左下角 计算出新的中心点
  let newCenter = getNewCenter(freezePoint, endRotatedTouchAnchorPoint);

  // 得到【touchEndPoint】---angle=0(右下角anchor)的坐标
  let endZeroTouchAnchorPoint: SimplePoint = calculatePointAfterRotateAngle(
    endRotatedTouchAnchorPoint,
    newCenter,
    -angle
  );

  // ---------- 使用transform之前的坐标计算出新的width和height ----------

  // 得到左上角---angle=0的坐标
  let zeroFreezePoint: SimplePoint = calculatePointAfterRotateAngle(
    freezePoint,
    newCenter,
    -angle
  );

  // transform之前的坐标的左上角+右下角计算出宽度和高度
  const width = Math.abs(endZeroTouchAnchorPoint.x - zeroFreezePoint.x);
  const height = Math.abs(endZeroTouchAnchorPoint.y - zeroFreezePoint.y);

  // ---------- 使用transform之前的坐标计算出新的width和height ----------

  return {
    width,
    height,
    center: newCenter,
  };
}
```

### 3.1 图解

- `第1个图=>第2个图`：利用目前已知的坐标`oldCenter`、`startRotatedTouchAnchorPoint`(也就是 anchor 坐标)、手指触摸的距离（也就是 onDraging 得到的 dx 和 dy），我们可以计算得到的坐标`endRotatedTouchAnchorPoint`和`freezePoint`
- `第2个图=>第3个图`：利用`freezePoint`和`endRotatedTouchAnchorPoint`，我们可以得到新的中心点`newCenter`
- `第3个图=>第4个图`：自此我们知道了几乎所有点的坐标，我们进行`-angle`的翻转得到去掉`transform`的图形以及对应的坐标（也就是`rotate=0`的图形）
- `第4个图`：利用`rotate=0`的图形顺利计算出新的 width 和 height 以及 newCenter 和 oldCenter 之间的偏移量 deltaX 和 deltaY

![2 1](https://github.com/user-attachments/assets/99a34609-71ef-4e7f-a14d-8f3ac9aab16c)

### 3.2 freezeWidth 和 freezeHeight

当加入`freezeWidth`和`freezeHeight`后，情况会变的比较复杂，因为 rotate 不为 0 的时候，recalcRotatedResizeInfo()计算出来的中心点会发生变化，因此我们不能简单限制`freezeWidth`，我们就设置为`deltaX=0`，我们还是得计算出来`deltaX`和`deltaY`

因此我们在原来的`calculateWidthAndHeight()`加入一段修正`deltaX`和`deltaY`的逻辑

> 下面将通过图示进行思路的讲解

```ts
export function calculateWidthAndHeight(...) {
  //...freezeWidth和freezeHeight都为false的坐标获取逻辑

  if (freezeWidth) {
    // 如果固定width，那么不能单纯使用endZeroTouchAnchorPoint.x=startZeroTouchAnchorPoint.x
    // 因为去掉transform的左上角不一定是重合的，我们要保证的是transform后的左上角重合
    const newWidth = Math.abs(endZeroTouchAnchorPoint.x - zeroFreezePoint.x);
    const widthDx = newWidth - oldWidth;

    // 点击的是左边锚点，是+widthDx/2，点击是右边锚点，是-widthDx/2
    if (newCenter.x > endZeroTouchAnchorPoint.x) {
      // 当前触摸的是左边锚点
      newCenter.x = newCenter.x + widthDx / 2;
    } else {
      // 当前触摸的是右边锚点
      newCenter.x = newCenter.x - widthDx / 2;
    }
  }
  if (freezeHeight) {
    //...与freezeWidth处理相同
  }

  if (freezeWidth || freezeHeight) {
    // 如果调整过transform之前的坐标，那么transform后的坐标也会改变，那么算出来的newCenter也得调整
    // 由于无论如何rotate，中心点都是不变的，因此我们可以使用transform之前的坐标算出新的中心点
    const nowFreezePoint = calculatePointAfterRotateAngle(
      zeroFreezePoint,
      newCenter,
      angle
    );

    // 得到当前新rect的左上角与实际上transform后的左上角的偏移量
    const dx = nowFreezePoint.x - freezePoint.x;
    const dy = nowFreezePoint.y - freezePoint.y;

    // 修正不使用transform的坐标: 左上角、右下角、center
    newCenter.x = newCenter.x - dx;
    newCenter.y = newCenter.y - dy;
    zeroFreezePoint = calculatePointAfterRotateAngle(
      freezePoint,
      newCenter,
      -angle
    );
    endZeroTouchAnchorPoint = {
      x: newCenter.x - (zeroFreezePoint.x - newCenter.x),
      y: newCenter.y - (zeroFreezePoint.y - newCenter.y),
    };
  }

  //...利用rotate=0的图形顺利计算出新的width和height

  return {
    width,
    height,
    center: newCenter,
  };
}
```

- `图1->图2`: 当`freezeWidth=true`时，我们进行宽度的恢复，得出需要减去的宽度`widthDx`
- `图2->图3`: 我们使用减去的宽度`widthDx`去修正目前的中心点`newCenter.x=newCenter.x-widthDx/2`
- `图3->图4`: 我们旋转`angle`得到 transform 后的左上角坐标，此时应该保持一致，因此我们可以得出目前的偏移量，通过偏移量，我们整体平移图形，修正`newCenter`的误差
- `图4->图5`: 通过准确的`newCenter`以及固定不变的`freezePoint`，我们可以计算出新的左上角和右下角，然后计算出`width`和`height`

![2 2](https://github.com/user-attachments/assets/e950d004-bf4f-4e14-83bc-982dfd4021ea)

## 3.3 其他小优化点

### 3.3.1 freezeWidth 和 freezeHeight 滑动卡顿问题

当`freezeWidth=true`时，`minWidth等于maxHeight`，因此`nextSize.width`必须等于`minWidth`
`rotate!==0`触发`calculateWidthAndHeight()`计算`width`和`height`，理论计算出来的`nextSize.width`必须等于`oldWidth`，但是实际上有误差，比如

- oldWidth = 100
- newWidth=100.000000000001

因此在`calculateWidthAndHeight()`直接`width = oldWidth`，防止误差导致`cancelDrag()`发生

```ts
export const handleResize = ({...}) => {
  //...
  const nextSize = recalcResizeInfo(...);

  // 限制放大缩小的最大最小范围
  if (
    nextSize.width < minWidth ||
    nextSize.width > maxWidth ||
    nextSize.height < minHeight ||
    nextSize.height > maxHeight
  ) {
    // this.dragHandler.cancelDrag()
    cancelCallback?.();
    return;
  }
  //...
};
export function calculateWidthAndHeight(...) {
  //...
  if (freezeWidth) {
    // 理论计算出来的width应该等于oldWidth
    // 但是有误差，比如oldWidth = 100; newWidth=100.000000000001
    // 会在handleResize()限制放大缩小的最大最小范围中被阻止滑动
    width = oldWidth;
  }
  if (freezeHeight) {
    height = oldHeight;
  }

  return {
    width,
    height,
    center: newCenter,
  };
}

```

### 3.3.2 onDragging 没有销毁注册事件

如下面视频所示，有一定小概率会发生，当`ResizeControlGroup`销毁时，也就是 Resize 的组件销毁时，此时的`DOC.removeEventListener("mousemove")`没有触发，也就是没有销毁注册监听，导致 onDragging 一直触发，造成滑动错乱情况发生

https://github.com/user-attachments/assets/6ec24fd7-3ca6-4740-b7af-ea6de0dd67d7

通过代码分析，当`<ResizeControlGroup>`在滑动过程中因为某些原因造成销毁，并且在销毁前没有触发`handleMouseUp()`事件，也就是跟视频展示一样，在滑动过程中，某些特殊原因导致滑动过程中就触发`ResizeControlGroup`销毁时，还没来得及触发`handleMouseUp()`时，就会导致`window?.document`注册的`mousemove`一直存在！

```ts
class BaseNode extends Component {
    getResizeControl(): h.JSX.Element | null {
        const { model, graphModel } = this.props
        const {
        editConfigModel: { isSilentMode, allowResize },
        } = graphModel
        const { isSelected, isHitable, resizable, isHovered } = model

        // 合并全局 allResize 和节点自身的 resizable 配置，以节点配置高于全局配置
        const canResize = allowResize && resizable // 全局开关 > 节点配置
        const style = model.getResizeControlStyle()
        if (!isSilentMode && isHitable && (isSelected || isHovered) && canResize) {
            return (
                <ResizeControlGroup
                    style={style}
                    model={model}
                    graphModel={graphModel}
                />
            )
        }
        return null
    }
}
export class ResizeControl extends Component<> {

  constructor(props: IResizeControlProps) {
    //...

    // 初始化拖拽工具
    this.dragHandler = new StepDrag({
      onDragging: this.onDragging,
      onDragEnd: this.onDragEnd,
      step: graphModel.gridSize,
    });
  }

  handleMouseDown = (e: MouseEvent) => {
    const DOC: any = window?.document;
    //...

    DOC.addEventListener("mousemove", this.handleMouseMove, false);
    DOC.addEventListener("mouseup", this.handleMouseUp, false);
    //...
  };

  handleMouseUp = (e: MouseEvent) => {
    const DOC = window.document
    //...
    Promise.resolve().then(() => {
      DOC.removeEventListener('mousemove', this.handleMouseMove, false)
      DOC.removeEventListener('mouseup', this.handleMouseUp, false)
    });
}
```

因此在`ResizeControl`销毁时，应该主动触发一次事件销毁`this.dragHandler.cancelDrag()`，才能避免一些错乱事情发生

> 目前只在`ResizeControl`中加入`componentWillUnmount`进行`this.dragHandler.cancelDrag()`，按照道理，其它有用到`DOC.addEventListener("mousemove")`都应该在组件销毁时显式触发一次事件监听销毁，这里没有深入去排查

```ts
export class ResizeControl extends Component<> {

  constructor(props: IResizeControlProps) {
    //...

    // 初始化拖拽工具
    this.dragHandler = new StepDrag({
      onDragging: this.onDragging,
      onDragEnd: this.onDragEnd,
      step: graphModel.gridSize,
    });
  }

  componentWillUnmount() {
    this.dragHandler.cancelDrag()
  }

  handleMouseDown = (e: MouseEvent) => {
    const DOC: any = window?.document;
    //...

    DOC.addEventListener("mousemove", this.handleMouseMove, false);
    DOC.addEventListener("mouseup", this.handleMouseUp, false);
    //...
  };

  handleMouseUp = (e: MouseEvent) => {
    const DOC = window.document
    //...
    Promise.resolve().then(() => {
      DOC.removeEventListener('mousemove', this.handleMouseMove, false)
      DOC.removeEventListener('mouseup', this.handleMouseUp, false)
    });
}
```

## 4. 测试代码和效果视频

### 4.1 正常模式的 rotate+resize

代码已经上传到`examples/feature-examples/src/pages/graph/index.tsx`

https://github.com/user-attachments/assets/a2591e16-52ae-45c8-abe0-dbd5df5e42bc

### 4.2 freezeWidth 和 freezeHeight

由于代码中好像没有实现`maxHeight`和`minHeight`的初始化处理，因此我添加了一些测试代码，没有上传

在`examples/feature-examples/src/pages/nodes/native/index.tsx`

- `const data = {}`增加测试数据`freeWidth矩形`和`freeHeight矩形`
- `const config`增加配置`allowRotate=true`和`allowResize=true`

```js
const config = {
  //...省略很多数据
  allowRotate: true,
  allowResize: true,
}
const data = {
  nodes: [
    //...省略很多数据
    {
      id: "8",
      type: "rect",
      x: 350,
      y: 400,
      rotate: Math.PI * 0.2,
      properties: {
        width: 100,
        height: 100,
        minWidth: 100,
        maxWidth: 100,
      },
      text: "freeWidth矩形",
    },
    {
      id: "9",
      type: "rect",
      x: 550,
      y: 400,
      rotate: Math.PI * 0.3，
      properties: {
        width: 100,
        height: 100,
        minHeight: 100,
        maxHeight: 100,
      },
      text: "freeHeight矩形",
    },
  ],
};
```

在`packages/core/src/model/node/RectNodeModel.ts`的`setAttributes()`增加

- `this.minWidth = minWidth`
- `this.maxWidth = maxWidth`
- `this.minHeight = minHeight`
- `this.maxHeight = maxHeight`

```ts
  setAttributes() {
    super.setAttributes()

    const { width, height, radius, minWidth, maxWidth, minHeight, maxHeight } =
      this.properties
    if (!isNil(width)) this.width = width
    if (!isNil(height)) this.height = height
    // @ts-ignore
    if (!isNil(minWidth)) this.minWidth = minWidth
    // @ts-ignore
    if (!isNil(maxWidth)) this.maxWidth = maxWidth
    // @ts-ignore
    if (!isNil(minHeight)) this.minHeight = minHeight
    // @ts-ignore
    if (!isNil(maxHeight)) this.maxHeight = maxHeight

    // 矩形特有
    if (!isNil(radius)) this.radius = radius
  }
```

https://github.com/user-attachments/assets/281de1e5-a97d-4fa9-977d-477c4ac56752
