### PR TITLE
docs(site): 完善快速上手 cdn 引入示例

### DIFF
--- a/sites/docs/docs/tutorial/get-started.en.md
+++ b/sites/docs/docs/tutorial/get-started.en.md
@@ -75,7 +75,7 @@ By default, the CDN will include the latest version. To include a different vers
 ### 1. Using in Native JS
 
 ```html | pure
-<!-- Include core package -->
+<!-- Include core package And css -->
 <script src="https://cdn.jsdelivr.net/npm/@logicflow/core/dist/index.min.js"></script>
 <link href="https://cdn.jsdelivr.net/npm/@logicflow/core/lib/style/index.min.css" rel="stylesheet">
 
@@ -83,6 +83,9 @@ By default, the CDN will include the latest version. To include a different vers
 <div id="container"></div>
 
 <script>
+// Include inheritance nodes. After including the core package, window.Core will be automatically attached.
+// const { RectNode, RectNodeModel } = Core;
+
 // Prepare graph data
 const data = {
   // Nodes
@@ -112,7 +115,7 @@ const data = {
   ],
 }
 
-// Create canvas instance
+// Create canvas instance. You can also use new Core.LogicFlow.
 const lf = new Core.default({
   container: document.querySelector('#container'),
   width: 700,

--- a/sites/docs/docs/tutorial/get-started.zh.md
+++ b/sites/docs/docs/tutorial/get-started.zh.md
@@ -79,7 +79,7 @@ entension包</a> ，再根据自己的诉求在cdn路径中加上包版本。
 ### 1. 在原生JS环境下使用
 
 ```html | pure
-<!-- 引入 core包 -->
+<!-- 引入 core 包和对应 css-->
 <script src="https://cdn.jsdelivr.net/npm/@logicflow/core/dist/index.min.js"></script>
 <link href="https://cdn.jsdelivr.net/npm/@logicflow/core/lib/style/index.min.css" rel="stylesheet">
 
@@ -87,6 +87,9 @@ entension包</a> ，再根据自己的诉求在cdn路径中加上包版本。
 <div id="container"></div>
 
 <script>
+// 引入继承节点，引入 core 包后，会自动挂载 window.Core 
+// const { RectNode, RectNodeModel } = Core;
+
 // 准备图数据
 const data = {
   // 节点
@@ -115,7 +118,8 @@ const data = {
     },
   ],
 }
-// 创建画布实例
+
+// 创建画布实例，也可以 new Core.LogicFLow
 const lf = new Core.default({
   container: document.querySelector('#container'),
   width: 700,


### PR DESCRIPTION
- 在使用 cdn时，有用户引入继承节点是通过 import 引入的:

❌
```js
import { RectNode, RectNodeModel } from '@logicflow/core';

```

✅：

```js 
const { RectNode, RectNodeModel } = Core;
```

所以给官网「快速上手」页中 cdn 方式完善下 demo：
![image](https://github.com/user-attachments/assets/3e5f26df-972c-4efe-8a73-96261c764aac)
