### PR TITLE
fix(extension): 【dynamic-group】修复resize和move的冲突问题(#1826)

### DIFF
--- a/packages/core/src/model/node/BaseNodeModel.ts
+++ b/packages/core/src/model/node/BaseNodeModel.ts
@@ -306,6 +306,18 @@ export class BaseNodeModel<P extends PropertiesType = PropertiesType>
     if (isObservable(properties)) {
       properties = toJS(properties)
     }
+    if (isNil(properties.width)) {
+      // resize()的时候会触发this.setProperties({width,height})
+      // 然后返回getData()，可以从properties拿到width
+      // 但是初始化如果没有在properties传入width，那么getData()就一直无法从properties拿到width
+      properties.width = this.width
+    }
+    if (isNil(properties.height)) {
+      // resize()的时候会触发this.setProperties({width,height})
+      // 然后返回getData()，可以从properties拿到height
+      // 但是初始化如果没有在properties传入height，那么getData()就一直无法从properties拿到width
+      properties.height = this.height
+    }
     const data: NodeData = {
       id: this.id,
       type: this.type,


### PR DESCRIPTION
related:  [https://github.com/didi/LogicFlow/issues/1826](https://github.com/didi/LogicFlow/issues/1826)

## 问题出现的原因
> 注：本次pr建立在`rotate=0`的情况下，还没涉及到`rotate不等于0`的适配，因为涉及到`bbox`的调整，需要后续再优化`rotate不等于0`的情况....

目前`dynamic-group`的`resize`操作存在两个问题：
1. `group`里面的`item`没有按照比例进行缩放
2. `group`缩放时，会触发`this.x`和`this.y`的改变，同时也会触发`group.item`的`this.x`和`this.y`改变，然后`group`的`resize`再次出发`group.item`的`this.x`和`this.y`的改变，从而造成了两倍，也就是`this.x=this.x+2*deltaX`

### 问题1分析
由于比较简单，因此这里不再做详细分析，如下图所示，应该根据group.item.width在group.width所占的比例进行deltaX的换算
![pr-1](https://github.com/user-attachments/assets/d3d70dc4-a885-471c-8bef-8ad55a7dacf4)

### 问题2分析
```ts
class BaseNodeModel {
  resize(resizeInfo: ResizeInfo): ResizeNodeData {
    const { width, height, deltaX, deltaY } = resizeInfo;
    // 移动节点以及文本内容
    this.move(deltaX / 2, deltaY / 2);
    //...
  }
  move(deltaX: number, deltaY: number, isIgnoreRule = false): boolean {
    const { isAllowMoveX, isAllowMoveY } = this.isAllowMoveByXORY(
      deltaX,
      deltaY,
      isIgnoreRule
    );
    //...
  }
  isAllowMoveByXORY(deltaX: number, deltaY: number, isIgnoreRule: boolean) {
    let isAllowMoveX: boolean;
    let isAllowMoveY: boolean;
    if (isIgnoreRule) {
      isAllowMoveX = true;
      isAllowMoveY = true;
    } else {
      const r = this.isAllowMoveNode(deltaX, deltaY);
      //...
    }
    return {
      isAllowMoveX,
      isAllowMoveY,
    };
  }
  isAllowMoveNode(deltaX: number, deltaY: number): boolean | Model.IsAllowMove {
    let isAllowMoveX = true;
    let isAllowMoveY = true;
    const rules = this.moveRules.concat(this.graphModel.nodeMoveRules);
    for (const rule of rules) {
      const r = rule(this, deltaX, deltaY);
      //...
    }
    return {
      x: isAllowMoveX,
      y: isAllowMoveY,
    };
  }
}
```
而上面的this.graphModel.nodeMoveRules就是在`packages/extension/src/dynamic-group/index.ts`中增加的移动规则
```ts
graphModel.addNodeMoveRules((model, deltaX, deltaY) => {
    // 判断如果是 group，移动时需要同时移动组内的所有节点
    if (model.isGroup) {
      const nodeIds = this.getNodesInGroup(model as DynamicGroupNodeModel)
      graphModel.moveNodes(nodeIds, deltaX, deltaY, true)
      return true
    }
    //...
}
```

因此`group`缩放时，会触发`this.x`和`this.y`的改变，同时也会触发`group.item`的`this.x`和`this.y`改变

----------------

然后`group`的`resize`再次出发`group.item`的`this.x`和`this.y`的改变，如下面代码所示

```ts
eventCenter.on("node:resize", ({ deltaX, deltaY, index, model }) => {
  // TODO: 目前 Resize 的比例值有问题，导致缩放时，节点会变形，需要修复
  if (model.id === curGroup.id) {
    forEach(Array.from(curGroup.children), (childId) => {
      const child = graphModel.getNodeModelById(childId);
      if (child) {
        // child.rotate = model.rotate
        handleResize({
          deltaX,
          deltaY,
          index,
          nodeModel: child,
          graphModel,
          cancelCallback: () => {},
        });
      }
    });
  }
});
```
从而造成了两倍，也就是`this.x=this.x+2*deltaX`的现象

## 解决方法

### 问题1的解决方法
由于比较简单，因此这里直接贴代码展示，困惑点可能在于如果拿到group.width
![pr-2](https://github.com/user-attachments/assets/9ecc9986-4246-4212-964f-65e6e2c79c74)


在`node:resize`触发时，我们从下面代码可以知道，其实已经是调用`nodeModel.resize(nextSize)`才触发`triggerResizeEvent`，因此我们在`node:resize`拿到的`nodeModel`是已经缩放完成的`width`和`height`，我们需要拿没有`resize`之前的`width`和`height`去计算比例值，因此我们只能使用`preNodeData`

```ts
const handleResize = ({}) => {
  //...
  const nextSize = recalcResizeInfo(
    index,
    resizeInfo,
    pct,
    isFreezeWidth,
    isFreezeHeight
  );

  //...
  const preNodeData = nodeModel.getData();
  const curNodeData = nodeModel.resize(nextSize);

  // 更新边
  updateEdgePointByAnchors(nodeModel, graphModel);
  // 触发 resize 事件
  triggerResizeEvent(
    preNodeData,
    curNodeData,
    deltaX,
    deltaY,
    index,
    nodeModel,
    graphModel
  );
};
```

而这里有个奇怪的地方，虽然我们`nodeModel.resize`的时候（如下面代码所示），是进行了`setProperties({width,height})`，但是我们如果一开始没有传入`properties: {width:xxx, height:xxx}`，那我们上面代码中获取`preNodeData`拿到的`properties`是没有`width`和`height`，也无法从`preNodeData`拿到`width`和`height`
```ts
resize(resizeInfo: ResizeInfo): ResizeNodeData {
    const { width, height, deltaX, deltaY } = resizeInfo
    // 移动节点以及文本内容
    this.move(deltaX / 2, deltaY / 2)
  
    this.width = width
    this.height = height
    this.setProperties({
      width,
      height,
    })
    return this.getData()
}
getData(): NodeData {
    const { x, y, value } = this.text
    let { properties } = this
    if (isObservable(properties)) {
      properties = toJS(properties)
    }
    const data: NodeData = {
      id: this.id,
      type: this.type,
      x: this.x,
      y: this.y,
      properties,
    }
    if (this.rotate) {
      data.rotate = this.rotate
    }
    if (this.graphModel.overlapMode === OverlapMode.INCREASE) {
      data.zIndex = this.zIndex
    }
    if (value) {
      data.text = {
        x,
        y,
        value,
      }
    }
    return data
}
```
因此为了避免首次`preNodeData`中拿不到`width`和`height`
![pr-3](https://github.com/user-attachments/assets/a757c30b-812d-4a5d-a72b-8acf4da9ff68)

### 问题2的解决方法

问题2的核心问题是，在校验是否允许移动时，就进行了group.item的移动操作，因此我觉得应该移除这个逻辑
![pr-4](https://github.com/user-attachments/assets/621e1ab1-a24b-499b-9247-748bb0cb6e2b)

然后将`resize`和`move`两种操作分开处理，也就是监听
```ts
// 在 group 缩放时，对组内的所有子节点也进行对应的缩放计算`node:mousemove`进行组内的所有子节点的移动
eventCenter.on(
    'node:resize',
    ({ deltaX, deltaY, index, model, preData }) => {
      if (model.id === curGroup.id) {
        //...
      }
    },
  )

// 在 group 移动时，对组内的所有子节点也进行对应的移动计算
eventCenter.on('node:mousemove', ({ deltaX, deltaY, data }) => {
    if (data.id === curGroup.id) {
        const { model: curGroup, graphModel } = this.props
        const nodeIds = this.getNodesInGroup(curGroup, graphModel)
        graphModel.moveNodes(nodeIds, deltaX, deltaY, true)
    }
})
```

## 测试效果

https://github.com/user-attachments/assets/b941df3d-5f58-4be6-8241-599fa62969d2

如上面视频所示，`resize`和`move`都正常了，但是可以看出，分组缩小并没有限制，与下面两个issues反应的问题应该是一样的，这可能需要再另外进行优化处理
- [https://github.com/didi/LogicFlow/issues/1442](https://github.com/didi/LogicFlow/issues/1442)
- [https://github.com/didi/LogicFlow/issues/937](https://github.com/didi/LogicFlow/issues/937)
