### PR TITLE
fix(site): 文档勘误，插件的cdn使用方式错误

### DIFF
--- a/sites/docs/docs/tutorial/get-started.en.md
+++ b/sites/docs/docs/tutorial/get-started.en.md
@@ -199,7 +199,7 @@ For example, the control panel plugin provides zooming and fit-to-canvas capabil
   const { Control } = Extension;
   
   // Global level installation of the control panel plugin:
-  Core.use(Control);
+  Core.default.use(Control);
   
   // Instance level installation of the control panel plugin:
   const lf = new Core.default({

--- a/sites/docs/docs/tutorial/get-started.zh.md
+++ b/sites/docs/docs/tutorial/get-started.zh.md
@@ -182,8 +182,7 @@ LogicFlow初始化时支持不传画布宽高，这种情况下默认取的是co
 
 ### 3. 使用插件
 
-LogicFlow
-最初的目标就是提供一个扩展性强的流程绘制工具，用来满足各种业务需求。
+LogicFlow最初的目标就是提供一个扩展性强的流程绘制工具，用来满足各种业务需求。
 
 为了让LogicFlow的拓展性足够强，LogicFlow所有的非核心功能都使用插件的方式开发，并放到`@logicflow/extension`
 包中。
@@ -205,7 +204,7 @@ LogicFlow
   // Extension CDN会抛出一个包含所有插件的Extension变量，使用的插件需要从Extension中取用
   const { Control } = Extension
    //全局维度安装控制面板插件的写法：
-  Core.use(Control);
+  Core.default.use(Control);
    //实例维度安装控制面板插件的写法：
   const lf = new Core.default({
     ..., // 其他配置


### PR DESCRIPTION
现在写法：
![image](https://github.com/user-attachments/assets/b742d2f3-4400-4b50-a14a-880c4c305d80)

导致报错：
![image](https://github.com/user-attachments/assets/a094b5bd-9689-4c80-ac49-11c2331cc845)

修正：
![image](https://github.com/user-attachments/assets/8f8f47c8-e849-40e6-bd93-230f18db9c90)

