### PR TITLE
fix(core): update import path to relative path style to remove compilation error in angular

### DIFF
--- a/packages/core/src/util/graph.ts
+++ b/packages/core/src/util/graph.ts
@@ -1,5 +1,5 @@
 import LogicFlow from '..'
-import { EditConfigModel } from 'src/model'
+import { EditConfigModel } from '..'
 
 import PointTuple = LogicFlow.PointTuple
 


### PR DESCRIPTION
When using `@logicflow/core@2.0.4` with Angular v18 project, the angular compiler throws the following error:

```
✘ [ERROR] TS2307: Cannot find module 'src/model' or its corresponding type declarations. [plugin angular-compiler]

    node_modules/@logicflow/core/lib/util/graph.d.ts:1:32:
      1 │ import { EditConfigModel } from 'src/model';
```

This is because, for this particular file the import path was not given in relative style. This PR fixes this minor issue.