### PR TITLE
feat(extension):【dynamic-group】isRestrict分组缩放限制+transformWidthContainer控制子元素是否需要同时缩放

### DIFF
--- a/packages/core/src/model/BaseModel.ts
+++ b/packages/core/src/model/BaseModel.ts
@@ -56,6 +56,22 @@ export namespace Model {
     deltaY: number,
   ) => boolean | IsAllowMove
 
+  /**
+   * 限制节点resize规则
+   * model: 移动节点的 model
+   * deltaX: 中心点移动的 X 轴距离
+   * deltaY: 中心点移动的 Y 轴距离
+   * width: 中心点新的width
+   * height: 中心点新的height
+   */
+  export type NodeResizeRule = (
+    model: BaseNodeModel,
+    deltaX: number,
+    deltaY: number,
+    width: number,
+    height: number,
+  ) => boolean
+
   export type AdjustEdgeStartAndEndParams = {
     startPoint: LogicFlow.Point
     endPoint: LogicFlow.Point

--- a/packages/core/src/model/GraphModel.ts
+++ b/packages/core/src/model/GraphModel.ts
@@ -81,10 +81,15 @@ export class GraphModel {
 
   /**
    * 节点移动规则判断
-   * 在节点移动的时候，会出发此数组中的所有规则判断
+   * 在节点移动的时候，会触发此数组中的所有规则判断
    */
-
   nodeMoveRules: Model.NodeMoveRule[] = []
+  /**
+   * 节点resize规则判断
+   * 在节点resize的时候，会触发此数组中的所有规则判断
+   */
+  nodeResizeRules: Model.NodeResizeRule[] = []
+
   /**
    * 获取自定义连线轨迹
    */
@@ -1227,6 +1232,12 @@ export class GraphModel {
   addNodeMoveRules(fn: Model.NodeMoveRule) {
     if (!this.nodeMoveRules.includes(fn)) {
       this.nodeMoveRules.push(fn)
+    }
+  }
+
+  addNodeResizeRules(fn: Model.NodeResizeRule) {
+    if (!this.nodeResizeRules.includes(fn)) {
+      this.nodeResizeRules.push(fn)
     }
   }
 

--- a/packages/core/src/util/resize.ts
+++ b/packages/core/src/util/resize.ts
@@ -386,6 +386,12 @@ export const handleResize = ({
   const preNodeData = nodeModel.getData()
   const curNodeData = nodeModel.resize(nextSize)
 
+  // 检测preNodeData和curNodeData是否没变化
+  if (preNodeData.x === curNodeData.x && preNodeData.y === curNodeData.y) {
+    // 中心点x和y都没有变化，说明无法resize，阻止下面边的更新以及resize事件的emit
+    return
+  }
+
   // 更新边
   updateEdgePointByAnchors(nodeModel, graphModel)
   // 触发 resize 事件
@@ -417,7 +423,7 @@ export function calculateWidthAndHeight(
     y: oldCenter.y - (startRotatedTouchControlPoint.y - oldCenter.y),
   }
   // 【touchEndPoint】右下角 + freezePoint左上角 计算出新的中心点
-  let newCenter = getNewCenter(freezePoint, endRotatedTouchControlPoint)
+  const newCenter = getNewCenter(freezePoint, endRotatedTouchControlPoint)
 
   // 得到【touchEndPoint】右下角-没有transform的坐标
   let endZeroTouchControlPoint: SimplePoint = calculatePointAfterRotateAngle(

--- a/packages/extension/src/dynamic-group/model.ts
+++ b/packages/extension/src/dynamic-group/model.ts
@@ -50,6 +50,11 @@ export type IGroupNodeProperties = {
   // expandHeight?: number
 
   /**
+   * 缩放或旋转容器时，是否缩放或旋转组内节点
+   */
+  transformWidthContainer: boolean
+
+  /**
    * 当前分组元素的 zIndex
    */
   zIndex?: number
@@ -121,6 +126,7 @@ export class DynamicGroupNodeModel extends RectNodeModel<IGroupNodeProperties> {
       isRestrict,
       autoResize,
       autoToFront,
+      transformWidthContainer,
     } = data.properties ?? {}
 
     this.children = children ? new Set(children) : new Set()
@@ -139,6 +145,7 @@ export class DynamicGroupNodeModel extends RectNodeModel<IGroupNodeProperties> {
     this.collapsedHeight = collapsedHeight ?? DEFAULT_GROUP_COLLAPSE_HEIGHT
 
     this.isRestrict = isRestrict ?? false
+    this.transformWidthContainer = transformWidthContainer ?? true
     this.autoResize = autoResize ?? false
     this.collapsible = collapsible ?? true
     this.autoToFront = autoToFront ?? false

--- a/packages/extension/src/dynamic-group/model.ts
+++ b/packages/extension/src/dynamic-group/model.ts
@@ -52,7 +52,7 @@ export type IGroupNodeProperties = {
   /**
    * 缩放或旋转容器时，是否缩放或旋转组内节点
    */
-  transformWithContainer: boolean
+  transformWithContainer?: boolean
 
   /**
    * 当前分组元素的 zIndex
@@ -99,7 +99,7 @@ export class DynamicGroupNodeModel extends RectNodeModel<IGroupNodeProperties> {
   // 当前分组是否在可添加状态 - 实时状态
   @observable groupAddable: boolean = false
   // 缩放或旋转容器时，是否缩放或旋转组内节点
-  @observable transformWithContainer: boolean = true
+  @observable transformWithContainer: boolean = false
   childrenLastCollapseStateDict: Map<string, boolean> = new Map()
 
   constructor(data: NodeConfig<IGroupNodeProperties>, graphModel: GraphModel) {
@@ -145,7 +145,7 @@ export class DynamicGroupNodeModel extends RectNodeModel<IGroupNodeProperties> {
     this.collapsedHeight = collapsedHeight ?? DEFAULT_GROUP_COLLAPSE_HEIGHT
 
     this.isRestrict = isRestrict ?? false
-    this.transformWithContainer = transformWithContainer ?? true
+    this.transformWithContainer = transformWithContainer ?? false
     this.autoResize = autoResize ?? false
     this.collapsible = collapsible ?? true
     this.autoToFront = autoToFront ?? false

--- a/packages/extension/src/dynamic-group/model.ts
+++ b/packages/extension/src/dynamic-group/model.ts
@@ -52,7 +52,7 @@ export type IGroupNodeProperties = {
   /**
    * 缩放或旋转容器时，是否缩放或旋转组内节点
    */
-  transformWidthContainer: boolean
+  transformWithContainer: boolean
 
   /**
    * 当前分组元素的 zIndex
@@ -99,7 +99,7 @@ export class DynamicGroupNodeModel extends RectNodeModel<IGroupNodeProperties> {
   // 当前分组是否在可添加状态 - 实时状态
   @observable groupAddable: boolean = false
   // 缩放或旋转容器时，是否缩放或旋转组内节点
-  @observable transformWidthContainer: boolean = true
+  @observable transformWithContainer: boolean = true
   childrenLastCollapseStateDict: Map<string, boolean> = new Map()
 
   constructor(data: NodeConfig<IGroupNodeProperties>, graphModel: GraphModel) {
@@ -126,7 +126,7 @@ export class DynamicGroupNodeModel extends RectNodeModel<IGroupNodeProperties> {
       isRestrict,
       autoResize,
       autoToFront,
-      transformWidthContainer,
+      transformWithContainer,
     } = data.properties ?? {}
 
     this.children = children ? new Set(children) : new Set()
@@ -145,7 +145,7 @@ export class DynamicGroupNodeModel extends RectNodeModel<IGroupNodeProperties> {
     this.collapsedHeight = collapsedHeight ?? DEFAULT_GROUP_COLLAPSE_HEIGHT
 
     this.isRestrict = isRestrict ?? false
-    this.transformWidthContainer = transformWidthContainer ?? true
+    this.transformWithContainer = transformWithContainer ?? true
     this.autoResize = autoResize ?? false
     this.collapsible = collapsible ?? true
     this.autoToFront = autoToFront ?? false

--- a/packages/extension/src/dynamic-group/node.ts
+++ b/packages/extension/src/dynamic-group/node.ts
@@ -28,6 +28,10 @@ export class DynamicGroupNode<
 
     // 在 group 旋转时，对组内的所有子节点也进行对应的旋转计算
     eventCenter.on('node:rotate', ({ model }) => {
+      const { transformWidthContainer } = this.props.model
+      if (!transformWidthContainer) {
+        return
+      }
       // DONE: 目前操作是对分组内节点以节点中心旋转节点本身，而按照正常逻辑，应该是以分组中心，旋转节点（跟 Label 旋转操作逻辑一致）
       if (model.id === curGroup.id) {
         const center = { x: curGroup.x, y: curGroup.y }
@@ -60,6 +64,10 @@ export class DynamicGroupNode<
     eventCenter.on(
       'node:resize',
       ({ deltaX, deltaY, index, model, preData }) => {
+        const { transformWidthContainer } = this.props.model
+        if (!transformWidthContainer) {
+          return
+        }
         if (model.id === curGroup.id) {
           // node:resize是group已经改变width和height后的回调
           // 因此这里一定得用preData（没resize改变width之前的值），而不是data/model

--- a/packages/extension/src/dynamic-group/node.ts
+++ b/packages/extension/src/dynamic-group/node.ts
@@ -28,8 +28,14 @@ export class DynamicGroupNode<
 
     // 在 group 旋转时，对组内的所有子节点也进行对应的旋转计算
     eventCenter.on('node:rotate', ({ model }) => {
-      const { transformWithContainer } = this.props.model
-      if (!transformWithContainer) {
+      const { transformWithContainer, isRestrict } = this.props.model
+      if (!transformWithContainer || isRestrict) {
+        // isRestrict限制模式下，当前model resize时不能小于占地面积
+        // 由于parent:resize=>child:resize计算复杂，需要根据child:resize的判定结果来递归判断parent能否resize
+        // 不符合目前 parent:resize成功后emit事件 -> 触发child:resize 的代码交互模式
+        // 因此isRestrict限制模式下不支持联动(parent:resize=>child:resize)
+        // 由于transformWidthContainer是控制rotate+resize，为保持transformWidthContainer本来的含义
+        // parent:resize=>child:resize不支持，那么parent:rotate=>child:rotate也不支持
         return
       }
       // DONE: 目前操作是对分组内节点以节点中心旋转节点本身，而按照正常逻辑，应该是以分组中心，旋转节点（跟 Label 旋转操作逻辑一致）
@@ -64,8 +70,12 @@ export class DynamicGroupNode<
     eventCenter.on(
       'node:resize',
       ({ deltaX, deltaY, index, model, preData }) => {
-        const { transformWithContainer } = this.props.model
-        if (!transformWithContainer) {
+        const { transformWithContainer, isRestrict } = this.props.model
+        if (!transformWithContainer || isRestrict) {
+          // isRestrict限制模式下，当前model resize时不能小于占地面积
+          // 由于parent:resize=>child:resize计算复杂，需要根据child:resize的判定结果来递归判断parent能否resize
+          // 不符合目前 parent:resize成功后emit事件 -> 触发child:resize 的代码交互模式
+          // 因此isRestrict限制模式下不支持联动(parent:resize=>child:resize)
           return
         }
         if (model.id === curGroup.id) {

--- a/packages/extension/src/dynamic-group/node.ts
+++ b/packages/extension/src/dynamic-group/node.ts
@@ -28,8 +28,8 @@ export class DynamicGroupNode<
 
     // 在 group 旋转时，对组内的所有子节点也进行对应的旋转计算
     eventCenter.on('node:rotate', ({ model }) => {
-      const { transformWidthContainer } = this.props.model
-      if (!transformWidthContainer) {
+      const { transformWithContainer } = this.props.model
+      if (!transformWithContainer) {
         return
       }
       // DONE: 目前操作是对分组内节点以节点中心旋转节点本身，而按照正常逻辑，应该是以分组中心，旋转节点（跟 Label 旋转操作逻辑一致）
@@ -64,8 +64,8 @@ export class DynamicGroupNode<
     eventCenter.on(
       'node:resize',
       ({ deltaX, deltaY, index, model, preData }) => {
-        const { transformWidthContainer } = this.props.model
-        if (!transformWidthContainer) {
+        const { transformWithContainer } = this.props.model
+        if (!transformWithContainer) {
           return
         }
         if (model.id === curGroup.id) {

--- a/sites/docs/docs/tutorial/extension/dynamic-group.en.md
+++ b/sites/docs/docs/tutorial/extension/dynamic-group.en.md
@@ -143,10 +143,10 @@ export type IGroupNodeProperties = {
   /**
    * When scaling or rotating a container,
    * do you scale or rotate the nodes within the group
-   * Default to true, when scaling or rotating the container, 
+   * Default to false, when scaling or rotating the container, 
    * the nodes within the group are scaled or rotated by default
    */
-  transformWithContainer: boolean
+  transformWithContainer?: boolean
 
   /**
    * zIndex of the group element

--- a/sites/docs/docs/tutorial/extension/dynamic-group.en.md
+++ b/sites/docs/docs/tutorial/extension/dynamic-group.en.md
@@ -116,7 +116,8 @@ export type IGroupNodeProperties = {
    */
   isCollapsed?: boolean
   /**
-   * Whether to restrict the movement range of child nodes
+   * Whether to restrict the movement range of child nodes +
+   * Limit resizing to not exceed children's floor area
    * Defaults to false, allowing nodes to be dragged out of the group
    */
   isRestrict?: boolean
@@ -138,6 +139,14 @@ export type IGroupNodeProperties = {
    */
   collapsedWidth?: number
   collapsedHeight?: number
+
+  /**
+   * When scaling or rotating a container,
+   * do you scale or rotate the nodes within the group
+   * Default to true, when scaling or rotating the container, 
+   * the nodes within the group are scaled or rotated by default
+   */
+  transformWithContainer: boolean
 
   /**
    * zIndex of the group element
@@ -168,6 +177,7 @@ const dynamicGroupNodeConfig = {
     height: 250,
     radius: 5,
     isCollapsed: true,
+    transformWidthContainer: true,
   },
 }
 ```

--- a/sites/docs/docs/tutorial/extension/dynamic-group.zh.md
+++ b/sites/docs/docs/tutorial/extension/dynamic-group.zh.md
@@ -146,9 +146,9 @@ export type IGroupNodeProperties = {
 
   /**
    * 缩放或旋转容器时，是否缩放或旋转组内节点
-   * 默认为 true，缩放或旋转容器时，默认缩放或旋转组内节点
+   * 默认为 false，缩放或旋转容器时，默认缩放或旋转组内节点
    */
-  transformWithContainer: boolean
+  transformWithContainer?: boolean
 
   /**
    * 当前分组元素的 zIndex

--- a/sites/docs/docs/tutorial/extension/dynamic-group.zh.md
+++ b/sites/docs/docs/tutorial/extension/dynamic-group.zh.md
@@ -119,7 +119,8 @@ export type IGroupNodeProperties = {
    */
   isCollapsed?: boolean
   /**
-   * 子节点是否限制移动范围
+   * 子节点是否限制移动范围 + 
+   * 限制resize不能超过children占地面积
    * 默认为 false，允许拖拽移除分组
    */
   isRestrict?: boolean
@@ -142,6 +143,12 @@ export type IGroupNodeProperties = {
    */
   collapsedWidth?: number
   collapsedHeight?: number
+
+  /**
+   * 缩放或旋转容器时，是否缩放或旋转组内节点
+   * 默认为 true，缩放或旋转容器时，默认缩放或旋转组内节点
+   */
+  transformWithContainer: boolean
 
   /**
    * 当前分组元素的 zIndex
@@ -172,6 +179,7 @@ const dynamicGroupNodeConfig = {
     height: 250,
     radius: 5,
     isCollapsed: true,
+    transformWithContainer: true,
   },
 }
 ```


### PR DESCRIPTION
related 
- https://github.com/didi/LogicFlow/issues/1446
- https://github.com/didi/LogicFlow/issues/1442
- https://github.com/didi/LogicFlow/issues/937
以及
- https://github.com/didi/LogicFlow/issues/1826

## 前言

本次提交是`feature`，主要复用目前存在的`isRestrict`和`transformWithContainer`属性，实现分组缩放限制以及控制子元素是否需要同时缩放的功能
> 由于`rotate`相关逻辑需要很大工作量进行`bbox`的调整，因此本次提交仍然只针对`rotate=0`的情况，后续再进行`rotate`相关逻辑的优化

### 提交内容概述
- [x] New feature：复用isRestrict属性增加resize限制逻辑-根据内容占地位置来限制缩小范围
- [x] New feature：完善transformWithContainer参数控制子元素是否需要同时缩放的逻辑

### 提交列表
- feat：仿造moveRules，增加resizeRules规则进行节点resize限制
- feat：完善transformWidthContainer参数控制子元素是否需要同时缩放的逻辑
- chore: transformWidthContainer->transformWithContainer
- feat：isRestrict模式下增加resize限制逻辑-根据内容占地位置来限制缩小范围
- docs：增加isRestrict新的限制说明+transformWithContainer的说明

## 提交具体说明

### feat:仿造moveRules，增加resizeRules规则进行节点resize限制

在原来LogicFlow代码逻辑中，有`moveRules`可以进行移动相关的限制判断，如果不满足条件，则不允许进行移动

而分组缩放限制本质也是一种`resize`限制相关的需求，因此仿造moveRules，增加resizeRules规则进行节点resize限制

由于`resize`涉及到`rotate`相关的变化，可能会导致`x`、`y`、`width`、`height`多种属性变化，因此`resize`相关逻辑不能像下面`isAllowMoveNode()`还可以允许`x`不被允许，`y`可以被允许移动的情况，它更多是一种整体的变化，比如某一个属性`x`不被允许`resize`，那么`x`、`y`、`width`、`height`就应该就不被允许`resize`

```ts
class BaseNodeModel {
  /**
   * 内部方法
   * 是否允许移动节点到新的位置
   */
  isAllowMoveNode(deltaX: number, deltaY: number): boolean | Model.IsAllowMove {
    let isAllowMoveX = true
    let isAllowMoveY = true
    const rules = this.moveRules.concat(this.graphModel.nodeMoveRules)
    for (const rule of rules) {
      const r = rule(this, deltaX, deltaY)
      if (!r) return false
      if (typeof r === 'object') {
        const r1 = r as Model.IsAllowMove
        if (!r1.x && !r1.y) {
          return false
        }
        isAllowMoveX = isAllowMoveX && r1.x
        isAllowMoveY = isAllowMoveY && r1.y
      }
    }
    return {
      x: isAllowMoveX,
      y: isAllowMoveY,
    }
  }
}
```

因此在仿造moveRules的基础上进行方法的精简，去除`typeof r === 'object'`的相关判断
```ts
class BaseNodeModel {
    /**
     * 内部方法
     * 是否允许resize节点到新的位置
     */
    isAllowResizeNode(
        deltaX: number,
        deltaY: number,
        width: number,
        height: number,
    ): boolean {
        const rules = this.resizeRules.concat(this.graphModel.nodeResizeRules)
        for (const rule of rules) {
            const r = rule(this, deltaX, deltaY, width, height)
            if (!r) return false
        }
        return true
    }
}
```

> 除了精简返回值只能为`true`之外，`resizeRules`的函数还增加了`width`和`height`的传入，因为resize+rotata会导致`x`、`y`、`width`、`height`的变化，我们需要使用`x`、`y`、`width`、`height`重新计算出新的`bounds`，后面会进行具体的详细分析

### feat:完善transformWidthContainer参数控制子元素是否需要同时缩放的逻辑
> 感觉应该是写错了，应该是`transformWithContainer`，而不是`transformWidthContainer`，因此提交了`chore:transformWidthContainer->transformWithContainer`进行变量名称的修改

在原来LogicFlow代码逻辑中，就有`transformWithContainer`变量以及对应的注释


![transfomWithContainer](https://github.com/user-attachments/assets/b406e8a9-1108-4769-9aaf-672bfda9f41a)
---------------

但是初始化的时候，没有进行`transformWithContainer`的处理，在我的理解中，`transformWithContainer`应该是跟`isRestrict`同样的控制属性，因此使用同样的逻辑，从`data.properties`中获取，然后赋值给`this.transfromWithContainer`的模式


![transfromWithContainer1](https://github.com/user-attachments/assets/5c1b88fa-afc2-40d0-af07-1f0742fd0ede)
---------------

然后根据注释进行`node:rotate`和`node:resize`的阻止

![transfromWithContainer2](https://github.com/user-attachments/assets/ee061fea-1194-440e-a935-dd8bffb8c701)
---------------

### feat:isRestrict模式下增加resize限制逻辑-根据内容占地位置来限制缩小范围

在原来的isRestrict模式中，会限制子节点移动不能超过当前Node，在这个基础上，为isRestrict模式下增加resize限制逻辑：根据内容占地位置来限制缩小范围，也就是说：

当一个group处于isRestrict模式下时，它的子节点移动不能脱离group的范围，而group的resize操作也不能小于子节点的占地面积，如下面视频所示


https://github.com/user-attachments/assets/b4df5030-4a5f-47fa-991c-3c8857ef74fd

而增加的逻辑也非常简单，基本是仿造moveRules进行逻辑构建，如下面代码所示，触发`checkGroupBoundsWithChildren()`进行`resize`的判断
```ts
class DynamicGroup {  
    init() {
        // 添加分组节点移动规则
        // 1. 移动分组节点时，同时移动分组内所有节点
        // 2. 移动子节点时，判断是否有限制规则（isRestrict）
        graphModel.addNodeMoveRules((model, deltaX, deltaY) => {
            if (model.isGroup) {
                return true
            }
            const groupId = this.nodeGroupMap.get(model.id)!
            const groupModel = this.lf.getNodeModelById(
                groupId,
            ) as DynamicGroupNodeModel
            if (groupModel && groupModel.isRestrict) {
                // 如果移动的节点存在于某个分组中，且这个分组禁止子节点移出去
                const groupBounds = groupModel.getBounds()
                return isAllowMoveTo(groupBounds, model, deltaX, deltaY)
            }
            return true
        })

        // 添加分组节点resize规则
        // isRestrict限制模式下，当前model resize时不能小于children的占地面积
        graphModel.addNodeResizeRules((model, deltaX, deltaY, width, height) => {
            if (model.isGroup && model.isRestrict) {
                return this.checkGroupBoundsWithChildren(
                      model as DynamicGroupNodeModel,
                      deltaX,
                      deltaY,
                      width,
                      height,
                )
            }
            return true
        })
    }
}
```

> 而`addNodeResizeRules`是如何阻止resize的呢？

在`resize()`中，如果我们返回了`isAllowResize=false`，那么我们就阻止执行`this.move()`、`this.width`、`this.height`的更新，直接返回旧的`getData()`

```ts
// BaseNodeModel.ts
resize(resizeInfo: ResizeInfo): ResizeNodeData {
    const { width, height, deltaX, deltaY } = resizeInfo

    const isAllowResize = this.isAllowResizeNode(deltaX, deltaY, width, height)

    if (!isAllowResize) {
      return this.getData()
    }

    // 移动节点以及文本内容
    this.move(deltaX / 2, deltaY / 2)

    this.width = width
    this.height = height
    this.setProperties({
      width,
      height,
    })
    return this.getData()
}
```

当然我们也要同时阻止下当前node的children的相关resize逻辑，也就是

![transfrom3](https://github.com/user-attachments/assets/4405da48-1b83-47fd-b3d8-930b305c30e0)
-----------------


而检测group:resize后的bounds是否会小于children的bounds的逻辑也非常简单
- 首先根据上面`BaseNodeModel.ts`的`resize()`中的`this.move(deltaX / 2, deltaY / 2)`进行`x`和`y`的更新
- 根据新的`x`、`y`、`width`、`height`进行当前model新的bounds的计算，我们就可以得到parent:resize后的bounds
- 然后将parent:resize后的bounds与child:bounds进行比较，检测是否要阻止其resize

```ts
 /**
   * 检测group:resize后的bounds是否会小于children的bounds
   * 限制group进行resize时不能小于内部的占地面积
   * @param groupModel
   * @param deltaX
   * @param deltaY
   * @param newWidth
   * @param newHeight
   */
 checkGroupBoundsWithChildren(
    groupModel: DynamicGroupNodeModel,
    deltaX: number,
    deltaY: number,
    newWidth: number,
    newHeight: number,
  ) {
    if (groupModel.children) {
      const { children, x, y } = groupModel
      // 根据deltaX和deltaY计算出当前model的bounds
      const newX = x + deltaX / 2
      const newY = y + deltaY / 2
      const groupMinX = newX - newWidth / 2
      const groupMinY = newY - newHeight / 2
      const groupMaxX = newX + newWidth / 2
      const groupMaxY = newY + newHeight / 2

      const childrenArray = Array.from(children)
      for (let i = 0; i < childrenArray.length; i++) {
        const childId = childrenArray[i]
        const child = this.lf.getNodeModelById(childId)
        if (!child) {
          continue
        }
        const childBounds = child.getBounds()
        const { minX, minY, maxX, maxY } = childBounds
        // parent:resize后的bounds不能小于child:bounds，否则阻止其resize
        const canResize =
          groupMinX <= minX &&
          groupMinY <= minY &&
          groupMaxX >= maxX &&
          groupMaxY >= maxY
        if (!canResize) {
          return false
        }
      }
    }

    return true
  }
```

### transformWithContainer和isRestrict冲突问题

目前`group:resize`->`children:resize`的模式是通过emit事件的形式，也就是
- `group:resize`已经成功了，然后通知`children:resize`

当我们处于isRestrict模式时，我们需要限制`group:resize`完成后的`bounds`小于`children:resize`完成后的`bounds`，因此整个逻辑就会变成我们需要根据child:resize完成后的`bounds`来递归判断parent能否resize，我们得先完成`child:resize`->判断 `group:resize`能否执行

这其实跟目前的【`group:resize`已经成功了，然后通知`children:resize`】是冲突的，考虑实现的复杂性以及对应

- https://github.com/didi/LogicFlow/issues/1442
- https://github.com/didi/LogicFlow/issues/937

本质是基于1.x的Group提出的问题，1.x的Group就是没有联动效果的，也就是在 group 缩放时，组内的所有子节点不会进行对应的缩放计算

因此在此次pr中，当处于`isRestrict`模式时，直接阻止`transformWithContainer`的生效，也就是



![tranfrom4](https://github.com/user-attachments/assets/7921d977-fae2-487f-bbca-c87699c806cd)

----------------

### docs:增加isRestrict新的限制说明+transformWithContainer的说明

增加`dynamic-group.en.md`和`dynamic-group.zh.md`相关的文档说明，比如下面在`properties`增加`transformWithContainer`的声明

```ts
const dynamicGroupNodeConfig = {
  id: 'dynamic-group_1',
  type: 'dynamic-group',
  x: 500,
  y: 140,
  text: 'dynamic-group_1',
  resizable: true,
  rotatable: false,
  properties: {
    children: ["rect_3"],
    collapsible: true,
    width: 420,
    height: 250,
    radius: 5,
    isCollapsed: true,
    transformWithContainer: true,
  },
}
```