### PR TITLE
fix(extension): 【dynamic-group】存入history时，将text坐标恢复到未折叠前的数据(#1810)

### DIFF
--- a/packages/extension/src/dynamic-group/model.ts
+++ b/packages/extension/src/dynamic-group/model.ts
@@ -195,8 +195,15 @@ export class DynamicGroupNodeModel extends RectNodeModel<IGroupNodeProperties> {
       isCollapsed,
     } = this
     if (isCollapsed) {
+      // 如果当前是折叠模式
+      // 存入history的时候，将坐标恢复到未折叠前的坐标数据
+      // 因为拿出history数据的时候，会触发collapse()进行坐标的折叠计算
       data.x = x + expandWidth / 2 - collapsedWidth / 2
       data.y = y + expandHeight / 2 - collapsedHeight / 2
+      if (data.text) {
+        data.text.x = data.text.x + expandWidth / 2 - collapsedWidth / 2
+        data.text.y = data.text.y + expandHeight / 2 - collapsedHeight / 2
+      }
     }
     return data
   }


### PR DESCRIPTION
fix [https://github.com/didi/LogicFlow/issues/1810](https://github.com/didi/LogicFlow/issues/1810)

## 问题发生的原因

每次从`history`拿出数据后，都会触发`nodes`的重新渲染，然后触发`new Model()`
然后每次都会触发一次`setAttributes()`->`toggleCollapse()`->触发折叠后的坐标计算
```ts
class DynamicGroupNodeModel {
  constructor(data: NodeConfig<IGroupNodeProperties>, graphModel: GraphModel) {
    super(data, graphModel);
    this.childrenLastCollapseStateDict = new Map();

    this.initNodeData(data);
    this.setAttributes();
  }
  setAttributes() {
    super.setAttributes();

    // 初始化时，如果 this.isCollapsed 为 true，则主动触发一次折叠操作
    if (this.isCollapsed) {
      this.toggleCollapse(true);
    }
  }
}
```
```ts
// 折叠操作
collapse() {
    const { x, y, text, width, height, collapsedWidth, collapsedHeight } = this
    this.x = x - width / 2 + collapsedWidth / 2
    this.y = y - height / 2 + collapsedHeight / 2

    this.text.x = text.x - width / 2 + collapsedWidth / 2
    this.text.y = text.y - height / 2 + collapsedHeight / 2

    // 记录折叠前的节点大小，并将其记录到 expandWidth 中
    this.expandWidth = width
    this.expandHeight = height

    this.width = collapsedWidth
    this.height = collapsedHeight
}
```

因此存入history的坐标应该是未折叠前的坐标

在目前的代码中，确实重写了`getHistoryData()`，然后判断`isCollapsed`进行`this.x`和`this.y`坐标的恢复（即恢复到未折叠前的坐标），但是【漏了一个`text`坐标的恢复】 => 这导致存入history的text数据坐标是折叠后的坐标，从而导致坐标错乱，出现`issues/1810`展示的文字坐标错乱情况

```ts
getHistoryData(): NodeData {
    const data = super.getHistoryData()
    data.children = Array.from(this.children)
    data.isGroup = true

    const {
      x,
      y,
      collapsedWidth,
      collapsedHeight,
      expandWidth,
      expandHeight,
      isCollapsed,
    } = this
    if (isCollapsed) {
      data.x = x + expandWidth / 2 - collapsedWidth / 2
      data.y = y + expandHeight / 2 - collapsedHeight / 2
    }
    return data
}
```

## 解决方法
补上一个`data.text`坐标的恢复即可

```ts
getHistoryData(): NodeData {
    const data = super.getHistoryData()
    data.children = Array.from(this.children)
    data.isGroup = true

    const {
      x,
      y,
      collapsedWidth,
      collapsedHeight,
      expandWidth,
      expandHeight,
      isCollapsed,
    } = this
    if (isCollapsed) {
      // 如果当前是折叠模式
      // 存入history的时候，将坐标恢复到未折叠前的坐标数据
      // 因为拿出history数据的时候，会触发collapse()进行坐标的折叠计算
      data.x = x + expandWidth / 2 - collapsedWidth / 2
      data.y = y + expandHeight / 2 - collapsedHeight / 2
      if (data.text) {
        data.text.x = data.text.x + expandWidth / 2 - collapsedWidth / 2
        data.text.y = data.text.y + expandHeight / 2 - collapsedHeight / 2
      }
    }
    return data
}
```