### PR TITLE
feat(extension): 【dynamic-group】实现autoResize自动扩展父节点的功能(#1750)

### DIFF
--- a/packages/extension/src/dynamic-group/model.ts
+++ b/packages/extension/src/dynamic-group/model.ts
@@ -84,6 +84,8 @@ export class DynamicGroupNodeModel extends RectNodeModel<IGroupNodeProperties> {
   children!: Set<string>
   // 是否限制组内节点的移动范围。默认不限制 TODO: 完善该功能
   isRestrict: boolean = false
+  // isRestrict 模式启用时，如果同时设置 autoResize 为 true，那么子节点在父节点中移动时，父节点会自动调整大小
+  autoResize: boolean = false
   // 分组节点是否可以折叠
   collapsible: boolean = true
 


### PR DESCRIPTION
close [https://github.com/didi/LogicFlow/issues/1750](https://github.com/didi/LogicFlow/issues/1750)

## 背景


在原来的代码中，有对应的`autoResize`的注释和初始化代码，比如
```ts
export type IGroupNodeProperties = {
    /**
     * 子节点是否限制移动范围
     * 默认为 false，允许拖拽移除分组
     */
    isRestrict?: boolean
    /**
     * isRestrict 模式启用时，
     * 如果同时设置 autoResize 为 true，
     * 那么子节点在父节点中移动时，父节点会自动调整大小
     */
    autoResize?: boolean
} & IRectNodeProperties

export class DynamicGroupNodeModel extends RectNodeModel<IGroupNodeProperties> {

  initNodeData(data: LogicFlow.NodeConfig<IGroupNodeProperties>) {
    super.initNodeData(data)

    const {
      isRestrict,
      autoResize,
      //...
    } = data.properties ?? {}

    this.isRestrict = isRestrict ?? false
    this.autoResize = autoResize ?? false
    //...
  }
}
```

包括在`dynamic-group.zh.md`和`dynamic-group.en.md`都有对`autoResize`属性的说明，但是并没有真正实现该功能

------------------------------------------------


注：如 issues中所提到的[https://x6.antv.vision/zh/examples/node/group#expand-shrink](https://x6.antv.vision/zh/examples/node/group#expand-shrink)所示，实现的不仅仅是自动扩展，还有自动收缩的功能

看了[x6/expand-shrink](https://x6.antv.vision/zh/examples/node/group#expand-shrink)的代码，它的实现逻辑应该是：
- 为每一个`node`创建一个属性`originPosition`，此时的`node`就是`parentGroup`
- 每次拿出`parentGroup`的`originPosition bounds`与它的`所有children`的`bounds`进行比较，然后更新`parentGroup`
- 当`所有children`的`bounds`大于目前的`parentGroup`的`bounds` => 更新后会感觉是自动放大了
- 当`所有children`的`bounds`小于目前的`parentGroup`的`bounds`，但还是大于`parentGroup`的`originPosition bounds` => 更新后会感觉是自动缩小了
- 当`所有children`的`bounds`小于`parentGroup`的`originPosition bounds`  => 会恢复到原始的面积大小

实现逻辑并不复杂，就是在原来的基础上增加`originPosition`，每次使用`parentGroup originPosition`的`bounds`去操作，而不是目前的`parentGroup`的`bounds`


但是我个人觉得自动缩小功能很鸡肋，理由是：
- 这种自动收缩效果在[nodeSelection](https://site.logic-flow.cn/examples/extension/native/#nodeSelection)插件中是合理的，因为包裹的区域要紧紧贴着node，但是在不紧紧贴着node的【dynamic-group】中，自动缩小就会显得难以形成很好的交互体验
- 如[x6/expand-shrink](https://x6.antv.vision/zh/examples/node/group#expand-shrink)展示一样，你操作过程中其实都会忘记初始的node大小，但是你在移动子节点时，你会突然发现，某个时刻移动就会卡住（当`所有children`的`bounds`小于`parentGroup`的`originPosition bounds` ），你会感觉是不是哪里出问题，而不会想到是初始化面积就是这样子的，相反自动扩展就有非常明显的交互改变，A就是A，B就是B

因此本次pr只实现了自动扩展功能，而没有实现自动缩小功能
> 由于rotate相关逻辑需要很大工作量进行bbox的调整，因此本次提交仍然只针对rotate=0的情况，后续再进行rotate相关逻辑的优化

## 实现效果


https://github.com/user-attachments/assets/ac254a7c-e9d4-48cf-9f25-e2e984dfeeea



## 实现过程

### 完善初始化逻辑
```ts
export class DynamicGroupNodeModel extends RectNodeModel<IGroupNodeProperties> {
  // isRestrict 模式启用时，如果同时设置 autoResize 为 true，那么子节点在父节点中移动时，父节点会自动调整大小
  autoResize: boolean = false
}
```

### 监听元素的位置移动

```ts
lf.on('node:mousemove', this.onNodeMove)
```

逻辑比较简单，直接看下面代码的注释即可
```ts
onNodeMove = ({ deltaX, deltaY, data }) => {
    // 当前node获取它的parentGroup
    const { id, x, y, properties } = data
    const { width, height } = properties
    const groupId = this.nodeGroupMap.get(id)
    const groupModel = this.lf.getNodeModelById(
        groupId,
    ) as DynamicGroupNodeModel


    // 如果parentGroup不是 isRestrict&autoResize模式，则不需要执行下面的代码
    if (!groupModel || !groupModel.isRestrict || !groupModel.autoResize) {
        return
    }
    // step1: 计算出当前child的bounds
    const newX = x + deltaX / 2
    const newY = y + deltaY / 2
    const minX = newX - width! / 2
    const minY = newY - height! / 2
    const maxX = newX + width! / 2
    const maxY = newY + height! / 2

    // step2：比较当前child.bounds与parent.bounds的差异，比如child.minX<parent.minX，那么parent.minX=child.minX
    let hasChange = false
    const groupBounds = groupModel.getBounds()
    const newGroupBounds = Object.assign({}, groupBounds)
    if (minX < newGroupBounds.minX) {
      newGroupBounds.minX = minX
      hasChange = true
    }
    if (minY < newGroupBounds.minY) {
      newGroupBounds.minY = minY
      hasChange = true
    }
    if (maxX > newGroupBounds.maxX) {
      newGroupBounds.maxX = maxX
      hasChange = true
    }
    if (maxY > newGroupBounds.maxY) {
      newGroupBounds.maxY = maxY
      hasChange = true
    }
    if (!hasChange) {
      // 子元素没有超过parentGroup则不需要执行下面的代码
      return
    }

    // step3: 根据当前parent.bounds去计算出最新的x、y、width、height
    const newGroupX =
      newGroupBounds.minX + (newGroupBounds.maxX - newGroupBounds.minX) / 2
    const newGroupY =
      newGroupBounds.minY + (newGroupBounds.maxY - newGroupBounds.minY) / 2
    const newGroupWidth = newGroupBounds.maxX - newGroupBounds.minX
    const newGroupHeight = newGroupBounds.maxY - newGroupBounds.minY
    groupModel.moveTo(newGroupX, newGroupY)
    groupModel.width = newGroupWidth
    groupModel.height = newGroupHeight
};
```

