### PR TITLE
fix(vue-node-registry): 修复Teleport+KeepAlive场景下DOM重复渲染的问题(#1768)

### DIFF
--- a/examples/vue3-app/src/components/chart/linkChart.ts
+++ b/examples/vue3-app/src/components/chart/linkChart.ts
@@ -36,6 +36,10 @@ export default class LinkChart {
     // this.lf.render()
   }
 
+  destroy() {
+    this.lf.clearData()
+  }
+
   static create(options: IOptions) {
     return new LinkChart(options)
   }

--- a/examples/vue3-app/src/components/chart/linkChart.ts
+++ b/examples/vue3-app/src/components/chart/linkChart.ts
@@ -11,6 +11,7 @@ interface IOptions {
 
 export default class LinkChart {
   lf: LogicFlow
+  flowId: string = ''
 
   constructor(options: IOptions) {
     this.lf = new LogicFlow({
@@ -28,8 +29,10 @@ export default class LinkChart {
     })
     this.lf.graphModel.graphData = options.graphData
     const g = this.lf.extension.graph as any
+    this.lf.on('graph:rendered', ({ graphModel }) => {
+      this.flowId = graphModel.flowId!
+    })
     g.init()
-
     // this.lf.render()
   }
 

--- a/examples/vue3-app/src/views/KeepAliveAndTeleport.vue
+++ b/examples/vue3-app/src/views/KeepAliveAndTeleport.vue
@@ -14,6 +14,13 @@
         <component :is="LFChartView" :key="activeKey" :active-key="activeKey" />
       </KeepAlive>
     </div>
+    <div class="flex-1 overflow-hidden">
+      <component
+        :is="LFChartView"
+        :key="activeKey + 'notkeepalive'"
+        :active-key="activeKey + 'notkeepalive'"
+      />
+    </div>
   </div>
 </template>
 

--- a/examples/vue3-app/src/views/KeepAliveAndTeleport.vue
+++ b/examples/vue3-app/src/views/KeepAliveAndTeleport.vue
@@ -1,14 +1,6 @@
 <template>
   <div class="w-full h-full flex flex-col">
-    <el-tabs
-      hide-content
-      v-model="activeKey"
-      @tab-click="
-        (key: string) => {
-          activeKey = key as string
-        }
-      "
-    >
+    <el-tabs hide-content v-model="activeKey">
       <el-tab-pane name="page1" label="page1">
         <template #title> page1 </template>
       </el-tab-pane>
@@ -21,16 +13,13 @@
       <KeepAlive>
         <component :is="LFChartView" :key="activeKey" :active-key="activeKey" />
       </KeepAlive>
-      <TeleportContainer />
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { getTeleport } from '@logicflow/vue-node-registry'
 import { ref } from 'vue'
 import LFChartView from './LFChartView.vue'
 
 const activeKey = ref('page1')
-const TeleportContainer = getTeleport()
 </script>

--- a/examples/vue3-app/src/views/LFChartView.vue
+++ b/examples/vue3-app/src/views/LFChartView.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="w-full h-full">
     <div ref="container" class="flow w-full h-full overflow-hidden" />
-    <!-- <TeleportContainer />-->
+    <TeleportContainer :flow-id="flowId" />
   </div>
 </template>
 
@@ -21,6 +21,7 @@ const TeleportContainer = getTeleport()
 const container = ref()
 const graphData = ref<IGraphData>()
 
+const flowId = ref('')
 onMounted(() => {
   graphData.value = {
     nodes: [
@@ -203,10 +204,11 @@ onMounted(() => {
       }
     ]
   }
-  LinkChart.create({
+  const linkChart = LinkChart.create({
     container: container.value,
     graphData: graphData.value
   })
+  flowId.value = linkChart.flowId!
 })
 </script>
 

--- a/examples/vue3-app/src/views/LFChartView.vue
+++ b/examples/vue3-app/src/views/LFChartView.vue
@@ -6,7 +6,7 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, ref } from 'vue'
+import { onMounted, onUnmounted, ref } from 'vue'
 import { getTeleport } from '@logicflow/vue-node-registry'
 import '@logicflow/core/lib/style/index.css'
 import LinkChart from '@/components/chart/linkChart'
@@ -22,6 +22,9 @@ const container = ref()
 const graphData = ref<IGraphData>()
 
 const flowId = ref('')
+
+let linkChart: LinkChart
+
 onMounted(() => {
   graphData.value = {
     nodes: [
@@ -204,11 +207,16 @@ onMounted(() => {
       }
     ]
   }
-  const linkChart = LinkChart.create({
+  linkChart = LinkChart.create({
     container: container.value,
     graphData: graphData.value
   })
   flowId.value = linkChart.flowId!
+})
+
+onUnmounted(() => {
+  // 非KeepAlive模式下应该主动触发destroy()方法触发LogicFlow.clearData()
+  linkChart && linkChart.destroy()
 })
 </script>
 

--- a/packages/vue-node-registry/src/view.ts
+++ b/packages/vue-node-registry/src/view.ts
@@ -1,7 +1,7 @@
 import { isVue2, isVue3, createApp, h, Vue2 } from 'vue-demi'
 import { HtmlNode } from '@logicflow/core'
 import { vueNodesMap } from './registry'
-import { isActive, connect } from './teleport'
+import { isActive, connect, disconnect } from './teleport'
 
 export class VueNodeView extends HtmlNode {
   root?: any
@@ -89,7 +89,7 @@ export class VueNodeView extends HtmlNode {
     const root = this.getComponentContainer()
     if (this.vm) {
       isVue2 && this.vm.$destroy()
-      isVue3 && this.vm.$destroy()
+      isVue3 && this.vm.unmount()
       this.vm = null
     }
     if (root) {
@@ -99,6 +99,9 @@ export class VueNodeView extends HtmlNode {
   }
 
   unmount() {
+    if (isActive()) {
+      disconnect(this.targetId())
+    }
     this.unmountVueComponent()
   }
 }

--- a/sites/docs/docs/tutorial/advanced/vue.en.md
+++ b/sites/docs/docs/tutorial/advanced/vue.en.md
@@ -24,89 +24,79 @@ Here's an example of how to use Vue 3:
 
 ```html
 <template>
-    <div ref="containerRef" id="graph" class="viewport"></div>
-    <TeleportContainer />
+  <div ref="containerRef" id="graph" class="viewport"></div>
+  <TeleportContainer :flow-id="flowId"/>
 </template>
 
 <script setup lang="ts">
-    import {
-        onMounted,
-        ref
-    } from 'vue'
-    import {
-        forEach,
-        map,
-        has
-    } from 'lodash-es'
-    import LogicFlow, {
-        ElementState,
-        LogicFlowUtil
-    } from '@logicflow/core'
-    import {
-        register,
-        getTeleport
-    } from '@logicflow/vue-node-registry'
-    import '@logicflow/core/es/index.css'
+  import { onMounted, ref } from 'vue'
+  import { forEach, map, has } from 'lodash-es'
+  import LogicFlow, { ElementState, LogicFlowUtil } from '@logicflow/core'
+  import { register, getTeleport } from '@logicflow/vue-node-registry'
+  import '@logicflow/core/es/index.css'
 
-    import ProgressNode from '@/components/LFElements/ProgressNode.vue'
+  import ProgressNode from '@/components/LFElements/ProgressNode.vue'
 
-    const lfRef = ref < LogicFlow | null > (null)
-    const containerRef = ref < HTMLDivElement | null > (null)
-    const TeleportContainer = getTeleport()
+  const lfRef = ref<LogicFlow | null>(null)
+  const containerRef = ref<HTMLDivElement | null>(null)
+  const TeleportContainer = getTeleport()
+  const flowId = ref('')
 
-    onMounted(() => {
-        if (containerRef.value) {
-            const lf = new LogicFlow({
-                container: containerRef.value,
-                grid: true,
-            })
+  onMounted(() => {
+    if (containerRef.value) {
+      const lf = new LogicFlow({
+        container: containerRef.value,
+        grid: true,
+      })
 
-            // Register custom Vue node
-            register({
-                type: 'custom-vue-node',
-                component: ProgressNode
-            }, lf)
+      // 注册自定义 vue 节点
+      register({
+        type: 'custom-vue-node',
+        component: ProgressNode
+      }, lf)
 
-            // Register events
-            lf.render({})
+      lf.on('graph:rendered', ({ graphModel }) => {
+        flowId.value = graphModel.flowId!
+      })
 
-            const node1 = lf.addNode({
-                id: 'vue-node-1',
-                type: 'custom-vue-node',
-                x: 80,
-                y: 80,
-                properties: {
-                    progress: 60,
-                    width: 80,
-                    height: 80
-                }
-            })
-            console.log('node1 --->>>', node1)
+      // 注册事件
+      lf.render({})
 
-            const node2 = lf.addNode({
-                id: 'vue-node-2',
-                type: 'custom-vue-node',
-                x: 360,
-                y: 80,
-                properties: {
-                    progress: 60,
-                    width: 80,
-                    height: 80
-                }
-            })
-
-            setInterval(() => {
-                const {
-                    properties
-                } = node2.getData()
-                console.log('properties.progress --->>>', properties?.progress)
-                if (has(properties, 'progress')) {
-                    const progress = properties?.progress
-                    node2.setProperty('progress', (progress + 10) % 100)
-                }
-            }, 2000)
+      const node1 = lf.addNode({
+        id: 'vue-node-1',
+        type: 'custom-vue-node',
+        x: 80,
+        y: 80,
+        properties: {
+          progress: 60,
+          width: 80,
+          height: 80
         }
-    })
+      })
+      console.log('node1 --->>>', node1)
+
+      const node2 = lf.addNode({
+        id: 'vue-node-2',
+        type: 'custom-vue-node',
+        x: 360,
+        y: 80,
+        properties: {
+          progress: 60,
+          width: 80,
+          height: 80
+        }
+      })
+
+      setInterval(() => {
+        const { properties } = node2.getData()
+        console.log('properties.progress --->>>', properties?.progress)
+        if (has(properties, 'progress')) {
+          const progress = properties?.progress
+          node2.setProperty('progress', (progress + 10) % 100)
+        }
+      }, 2000)
+    }
+  })
 </script>
 ```
 

--- a/sites/docs/docs/tutorial/advanced/vue.zh.md
+++ b/sites/docs/docs/tutorial/advanced/vue.zh.md
@@ -23,7 +23,7 @@ tag: 新特性
 ```html
 <template>
   <div ref="containerRef" id="graph" class="viewport"></div>
-  <TeleportContainer />
+  <TeleportContainer :flow-id="flowId"/>
 </template>
 
 <script setup lang="ts">
@@ -38,6 +38,7 @@ tag: 新特性
   const lfRef = ref<LogicFlow | null>(null)
   const containerRef = ref<HTMLDivElement | null>(null)
   const TeleportContainer = getTeleport()
+  const flowId = ref('')
 
   onMounted(() => {
     if (containerRef.value) {
@@ -51,6 +52,10 @@ tag: 新特性
         type: 'custom-vue-node',
         component: ProgressNode
       }, lf)
+
+      lf.on('graph:rendered', ({ graphModel }) => {
+        flowId.value = graphModel.flowId!
+      })
 
       // 注册事件
       lf.render({})


### PR DESCRIPTION
fix [https://github.com/didi/LogicFlow/issues/1768](https://github.com/didi/LogicFlow/issues/1768)
fix [https://github.com/didi/LogicFlow/issues/1862](https://github.com/didi/LogicFlow/issues/1862)


## 问题发生的原因

### 使用KeepAlive
当我们在page1的时候，先触发了`<TeleportContainer />`的渲染，然后执行`new LogicFlow()`

```vue
// examples/vue3-app/src/views/LFChartView.vue
<template>
  <div class="w-full h-full">
    <div ref="container" class="flow w-full h-full overflow-hidden" />
    <TeleportContainer />
  </div>
</template>
```

```ts
  linkChart = LinkChart.create({
    container: container.value,
    graphData: graphData.value
  })
// ...省略一系列new LogicFlow()的代码
```

当执行`new LogicFlow()`然后进行`LogicFlow.render()`后，我们会触发teleport.ts的connect方法，将当前的`flowId:nodeId`作为id添加到items中
```ts
const items = reactive<{ [key: string]: any }>({})

export function connect(
  id: string,
  component: any,
  container: HTMLDivElement,
  node: BaseNodeModel,
  graph: GraphModel,
) {
  if (active) {
    items[id] = markRaw(
      defineComponent({
        render: () =>
          h(Teleport, { to: container } as any, [
            h(component, { node, graph }),
          ]),
        provide: () => ({
          getNode: () => node,
          getGraph: () => graph,
        }),
      }),
    )
  }
}
```

此时，由于`items`是响应式的 => 它会触发收集它依赖的`effect`执行，也就是`getTeleport()`的`setup(){return ()=> {}}`执行

进行`items`的遍历，然后触发渲染出`Page1`
```ts
export function getTeleport(): any {
  if (!isVue3) {
    throw new Error('teleport is only available in Vue3')
  }
  active = true

  return defineComponent({
    setup() {
      return () =>
        h(
          Fragment,
          {},
          Object.keys(items).map((id) => h(items[id])),
        )
    },
  })
}
```

当我们从`page1`->`page2`的时候，跟上面的流程类似，我们会进行`new LogicFlow()`，又会重新触发一次`teleport.ts`的`connect`方法，将当前的`flowId:nodeId`作为id添加到items中，此时`items`有两个`flowId`的数据！
> 注意：因为`page1`持有一个`new LogicFlow()`，`page2`也持有一个`new LogicFlow()`，两者的flowId是不同的


然后跟上面流程一样，由于`items`是响应式的 => 它会触发收集它依赖的`effect`执行，也就是`getTeleport()`的`setup(){return ()=> {}}`执行

而由于`KeepAlive`的特性，`Page1`并没有实际销毁，它只是被隐藏了！因此此时是存在两个`effect`的！！
- Page1: `getTeleport()`的`setup(){return ()=> {}}`
- Page2: `getTeleport()`的`setup(){return ()=> {}}`

![两个effect](https://github.com/user-attachments/assets/9dc8af4e-9cf3-4213-9850-a6ed46eab380)

> 我们在`getTeleport(key)`的时候传入对应的变量名，我们可以从图中看到，我们虽然隐藏了`Page1`，但是`Page1`的`<TeleportContainer />`还是因为持有`items`这个响应式数据而触发重新渲染

由于此时Page1和Page2都共用一个items（具有两个id），因此
- Page1: `getTeleport()`的`setup(){return ()=> {}}` => 生成Page1和Page2
- Page2: `getTeleport()`的`setup(){return ()=> {}}` => 生成Page1和Page2

这就导致了当我们从`page1`->`page2`的时候，界面出现了两个`Page2`，其中1个`Page2`是`Page1`的`<TeleportContainer />`触发`setup`渲染`items`生成的
> 如果此时我们从`page1`->`page2`->`page1`，我们也可以发现界面也出现了两个`Page1`，就是上面的流程生成的数据

![两个effect](https://github.com/user-attachments/assets/4b6ff946-c2ab-4c89-b73c-a3b799c0fc6e)

--------------

> 而为什么Page1的`<TeleportContainer />`触发`setup`渲染`items`能生成`Page2`呢？

那是因为`connect`的时候传递的container都是已确定好的，也就是`items[Page2相关的id]`就只会生成Page2
```
export function connect(
  id: string,
  component: any,
  container: HTMLDivElement,
  node: BaseNodeModel,
  graph: GraphModel,
) {
  if (active) {
    items[id] = markRaw(
      defineComponent({
        render: () =>
          h(Teleport, { to: container } as any, [
            h(component, { node, graph }),
          ]),
        provide: () => ({
          getNode: () => node,
          getGraph: () => graph,
        }),
      }),
    )
  }
}
```

### 不使用KeepAlive

通过上面的分析，其实我们就能明白为什么不使用KeepAlive不会出现重复的Page2的现象了，那是因为Page1会自动销毁，因此不会因为`items`的变化而触发重新渲染

![非keepAlive模式](https://github.com/user-attachments/assets/28ec0d20-2262-4317-800d-75fa8e846b42)

但是不使用KeepAlive还是存在问题，问题就是当我们频繁`page1->page2->page1->page2->page1->>page2->page1`切换的时候，我们发现，`items`里面的数据越来越多，就算我们主动触发`LogicFlow.clearData()`也无法改变，因此这里的`items`的`id`销毁事件是缺失的


## 解决方法

### KeepAlive模式

为了更好解决这个问题，需要理清一下目前整体代码逻辑，以及为什么要使用`<TeleportContainer />`的写法

![teleport (1)](https://github.com/user-attachments/assets/87036ab3-abf7-4760-92c7-c2d7efcb356e)

> 那为什么一定要这么写呢？可以不写<TeleportContainer>吗？不写也可以渲染的

那得从`teleport`这个组件的作用说起，本质就是在某一个组件里面写对应的逻辑代码，比如传参之类的根据这个组件的业务去决定，但是它实际渲染会根据`to: container`内容去挂载 `DOM`

如下面所示，当我们使用`<TeleportContainer>`时，我们可以在渲染的时候再传入特定的 `props`，比如 `test=1`，那么这个时候我们就可以在渲染`h(Teleport)`传入特定的参数，而这个参数会跟`new LogicFlow`的参数共同作用于我们构建出来的`.vue 组件`

换句话，就是你可以在很远的组件中进行`new LogicFlow(传入一些参数)`，这些参数在构建你声明的 `vue组件`时会传入，然后你可以在距离`new LogicFlow(传入一些参数)`的地方进行`<TeleportContainer>`触发`teleport`渲染，同时传入一些你所在组件的` props `特定值的参数，这样效果等同于 `vue3` 的` teleport `!
![image](https://github.com/user-attachments/assets/3bcab30d-6b61-4cf6-aa68-75bd9404b1bd)


所以目前的模式是没什么问题，那么问题出在哪里呢？

我们的本意是想
![我们想要实现的](https://github.com/user-attachments/assets/61152295-07c3-4b56-bf22-81fc5eb5b913)

但是现实是

![两个effect](https://github.com/user-attachments/assets/4b6ff946-c2ab-4c89-b73c-a3b799c0fc6e)

因此我们的解决方法就是
![解决方法1](https://github.com/user-attachments/assets/810b3729-e950-41e6-81bb-3c21601c3c3f)

我们强制传入对应的`flowId`，进行`items`的筛选

![解决方法3](https://github.com/user-attachments/assets/3e8b9b41-19b5-4d63-ae75-724262931d74)

![解决方法2](https://github.com/user-attachments/assets/2d59afd4-a578-4348-98a5-8de6ba52c470)

### 不使用KeepAlive

![解决方法4](https://github.com/user-attachments/assets/f77495ab-7476-4120-b1e2-2a29135732cf)


## 文档以及examples更新

### 文档
增加了`flowId`的示例传入

### examples
- 增加`flowId`的传入的示例
- 增加了非keepAlive模式下的销毁测试代码示例