### PR TITLE
fix: 修复文本拖拽不符合预期的问题

### DIFF
--- a/packages/core/src/view/text/BaseText.tsx
+++ b/packages/core/src/view/text/BaseText.tsx
@@ -91,7 +91,7 @@ export class BaseText<
       graphModel: { transformModel },
     } = this.props
 
-    if (deltaX && deltaY) {
+    if (deltaX || deltaY) {
       const [curDeltaX, curDeltaY] = transformModel.fixDeltaXY(deltaX, deltaY)
       model.moveText(curDeltaX, curDeltaY)
     }


### PR DESCRIPTION
> 回答 ISSUE #1891 时发现节点或边的文本拖拽时存在未能完全跟随鼠标移动的问题

改动点：逻辑与改为逻辑或

逻辑与需要 deltaX 和 deltaY 都有位移才会更新文本的位置，如果是水平横向或纵向拖拽文本，则不会跟随鼠标移动；而实际上，在拖拽时，只要鼠标在水平或竖直方向有位移，都应该更新文本位置，故改为逻辑或。