### PR TITLE
fix: 修复 2.x 与 1.x 下相同的网格线宽，Grid 表现不一致的问题

### DIFF
--- a/examples/feature-examples/src/pages/grid/index.tsx
+++ b/examples/feature-examples/src/pages/grid/index.tsx
@@ -121,7 +121,7 @@ export default function SelectionSelectExample() {
   const lfRef = useRef<LogicFlow>()
   const [gridVisible, setGridVisible] = useState(true)
   const [gridType, setGridType] = useState<'dot' | 'mesh'>('dot')
-  const [gridSize, setGridSize] = useState(10)
+  const [gridSize, setGridSize] = useState(20)
   const containerRef = useRef<HTMLDivElement>(null)
 
   // 初始化 LogicFlow

--- a/packages/core/src/view/overlay/Grid.tsx
+++ b/packages/core/src/view/overlay/Grid.tsx
@@ -53,7 +53,7 @@ export class Grid extends Component<IProps> {
       <path
         d={d}
         stroke={color}
-        strokeWidth={strokeWidth}
+        strokeWidth={strokeWidth / 2}
         opacity={opacity}
         fill="transparent"
       />


### PR DESCRIPTION
> #1904 

重写 Grid 的时候没有考虑到原先只有一半的宽度可见，实际表现就是 2.x 的网格在相同的网格线宽下，线的宽度实际上是 1.x 的两倍。举个例子，使用下面的配置，在 1.x 下，网格的线宽实际上是 `stroke-width="0.5"`；而在 2.x 下，网格的线宽实际上是 `stroke-width="1"`。

```js
const gridConfig = {
  type: 'mesh',
  config: {
    thickness: 1
  }
}
```

考虑到迁移影响，这里就将 2.x 的表现调整为与 1.x 的表现一致。




