### PR TITLE
fix(extension): 【dynamic-group】修复mousemove和isCollapsed相关问题

### DIFF
--- a/packages/core/src/event/eventArgs.ts
+++ b/packages/core/src/event/eventArgs.ts
@@ -140,7 +140,7 @@ interface NodeEventArgs {
   /**
    * 拖拽外部拖入节点
    */
-  'node:dnd-drag': NodeEventArgsPick<'data'>
+  'node:dnd-drag': NodeEventArgsPick<'data' | 'e'>
   /**
    * 开始拖拽节点
    */

--- a/packages/extension/src/dynamic-group/model.ts
+++ b/packages/extension/src/dynamic-group/model.ts
@@ -161,9 +161,9 @@ export class DynamicGroupNodeModel extends RectNodeModel<IGroupNodeProperties> {
     super.setAttributes()
 
     // 初始化时，如果 this.isCollapsed 为 true，则主动触发一次折叠操作
-    if (this.isCollapsed) {
-      this.toggleCollapse(true)
-    }
+    // if (this.isCollapsed) {
+    //   this.toggleCollapse(true)
+    // }
   }
 
   getData(): NodeData {
@@ -446,7 +446,6 @@ export class DynamicGroupNodeModel extends RectNodeModel<IGroupNodeProperties> {
    * @param _nodeData
    */
   isAllowAppendIn(_nodeData: NodeData) {
-    console.info('_nodeData', _nodeData)
     // TODO: 此处使用 this.properties.groupAddable 还是 this.groupAddable
     // this.groupAddable 是否存在更新不及时的问题
     return true

--- a/packages/extension/src/dynamic-group/model.ts
+++ b/packages/extension/src/dynamic-group/model.ts
@@ -159,11 +159,6 @@ export class DynamicGroupNodeModel extends RectNodeModel<IGroupNodeProperties> {
 
   setAttributes() {
     super.setAttributes()
-
-    // 初始化时，如果 this.isCollapsed 为 true，则主动触发一次折叠操作
-    // if (this.isCollapsed) {
-    //   this.toggleCollapse(true)
-    // }
   }
 
   getData(): NodeData {
@@ -445,7 +440,8 @@ export class DynamicGroupNodeModel extends RectNodeModel<IGroupNodeProperties> {
    * TODO: 如何重写该方法呢？
    * @param _nodeData
    */
-  isAllowAppendIn(_nodeData: NodeData) {
+  isAllowAppendIn() {
+    // TODO @typescript-eslint/no-unused-vars错误=>暂时删除@param _nodeData
     // TODO: 此处使用 this.properties.groupAddable 还是 this.groupAddable
     // this.groupAddable 是否存在更新不及时的问题
     return true

--- a/packages/extension/src/dynamic-group/model.ts
+++ b/packages/extension/src/dynamic-group/model.ts
@@ -440,8 +440,8 @@ export class DynamicGroupNodeModel extends RectNodeModel<IGroupNodeProperties> {
    * TODO: 如何重写该方法呢？
    * @param _nodeData
    */
-  isAllowAppendIn() {
-    // TODO @typescript-eslint/no-unused-vars错误=>暂时删除@param _nodeData
+  // eslint-disable-next-line
+  isAllowAppendIn(_nodeData: NodeData) {
     // TODO: 此处使用 this.properties.groupAddable 还是 this.groupAddable
     // this.groupAddable 是否存在更新不及时的问题
     return true

--- a/packages/extension/src/dynamic-group/node.ts
+++ b/packages/extension/src/dynamic-group/node.ts
@@ -129,6 +129,14 @@ export class DynamicGroupNode<
     eventCenter.on('node:mousemove', this.onNodeMouseMove)
   }
 
+  componentWillUnmount() {
+    super.componentWillUnmount()
+    const { eventCenter } = this.props.graphModel
+    eventCenter.off('node:rotate', this.onNodeRotate)
+    eventCenter.off('node:resize', this.onNodeResize)
+    eventCenter.off('node:mousemove', this.onNodeMouseMove)
+  }
+
   /**
    * 获取分组内的节点
    * @param groupModel

--- a/packages/extension/src/dynamic-group/node.ts
+++ b/packages/extension/src/dynamic-group/node.ts
@@ -112,9 +112,16 @@ export class DynamicGroupNode<
     data,
   }: Omit<CallbackArgs<'node:mousemove'>, 'e' | 'position'>) => {
     const { model: curGroup, graphModel } = this.props
+    const { transformModel } = graphModel
+    const { SCALE_X, SCALE_Y } = transformModel
     if (data.id === curGroup.id) {
       const nodeIds = this.getNodesInGroup(curGroup, graphModel)
-      graphModel.moveNodes(nodeIds, deltaX, deltaY, true)
+      // https://github.com/didi/LogicFlow/issues/1914
+      // 当调用lf.fitView()时，会改变整体的SCALE_X和SCALE_Y
+      // 由于group的mousemove是在drag.ts的this.onDragging()处理的，在onDragging()里面进行SCALE的处理
+      // 而"node:mousemove"emit出来跟onDragging()是同时的，也就是emit出来的数据是没有经过SCALE处理的坐标
+      // 因此这里需要增加SCALE的处理
+      graphModel.moveNodes(nodeIds, deltaX / SCALE_X, deltaY / SCALE_Y, true)
     }
   }
 

--- a/packages/extension/src/dynamic-group/node.ts
+++ b/packages/extension/src/dynamic-group/node.ts
@@ -3,6 +3,7 @@ import LogicFlow, {
   h,
   RectNode,
   handleResize,
+  CallbackArgs,
 } from '@logicflow/core'
 import { forEach } from 'lodash-es'
 import { DynamicGroupNodeModel } from './model'
@@ -18,101 +19,114 @@ export interface IDynamicGroupNodeProps {
 export class DynamicGroupNode<
   P extends IDynamicGroupNodeProps = IDynamicGroupNodeProps,
 > extends RectNode<P> {
-  componentDidMount() {
-    super.componentDidMount()
+  childrenPositionMap: Map<string, Position> = new Map()
 
+  onNodeRotate = ({
+    model,
+  }: Omit<CallbackArgs<'node:rotate'>, 'e' | 'position'>) => {
     const { model: curGroup, graphModel } = this.props
-    const { eventCenter } = graphModel
+    const { transformWithContainer, isRestrict } = curGroup
+    const childrenPositionMap = this.childrenPositionMap
+    if (!transformWithContainer || isRestrict) {
+      // isRestrict限制模式下，当前model resize时不能小于占地面积
+      // 由于parent:resize=>child:resize计算复杂，需要根据child:resize的判定结果来递归判断parent能否resize
+      // 不符合目前 parent:resize成功后emit事件 -> 触发child:resize 的代码交互模式
+      // 因此isRestrict限制模式下不支持联动(parent:resize=>child:resize)
+      // 由于transformWidthContainer是控制rotate+resize，为保持transformWidthContainer本来的含义
+      // parent:resize=>child:resize不支持，那么parent:rotate=>child:rotate也不支持
+      return
+    }
+    // DONE: 目前操作是对分组内节点以节点中心旋转节点本身，而按照正常逻辑，应该是以分组中心，旋转节点（跟 Label 旋转操作逻辑一致）
+    if (model.id === curGroup.id) {
+      const center = { x: curGroup.x, y: curGroup.y }
+      forEach(Array.from(curGroup.children), (childId) => {
+        const child = graphModel.getNodeModelById(childId)
 
-    const childrenPositionMap: Map<string, Position> = new Map()
-
-    // 在 group 旋转时，对组内的所有子节点也进行对应的旋转计算
-    eventCenter.on('node:rotate', ({ model }) => {
-      const { transformWithContainer, isRestrict } = this.props.model
-      if (!transformWithContainer || isRestrict) {
-        // isRestrict限制模式下，当前model resize时不能小于占地面积
-        // 由于parent:resize=>child:resize计算复杂，需要根据child:resize的判定结果来递归判断parent能否resize
-        // 不符合目前 parent:resize成功后emit事件 -> 触发child:resize 的代码交互模式
-        // 因此isRestrict限制模式下不支持联动(parent:resize=>child:resize)
-        // 由于transformWidthContainer是控制rotate+resize，为保持transformWidthContainer本来的含义
-        // parent:resize=>child:resize不支持，那么parent:rotate=>child:rotate也不支持
-        return
-      }
-      // DONE: 目前操作是对分组内节点以节点中心旋转节点本身，而按照正常逻辑，应该是以分组中心，旋转节点（跟 Label 旋转操作逻辑一致）
-      if (model.id === curGroup.id) {
-        const center = { x: curGroup.x, y: curGroup.y }
-        forEach(Array.from(curGroup.children), (childId) => {
-          const child = graphModel.getNodeModelById(childId)
-
-          if (child) {
-            let point: Position = { x: child.x, y: child.y }
-            if (childrenPositionMap.has(child.id)) {
-              point = childrenPositionMap.get(child.id)!
-            } else {
-              childrenPositionMap.set(child.id, point)
-            }
-
-            // 弧度转角度
-            let theta = model.rotate * (180 / Math.PI)
-            if (theta < 0) theta += 360
-            const radian = theta * (Math.PI / 180)
-
-            const newPoint = rotatePointAroundCenter(point, center, radian)
-
-            child.moveTo(newPoint.x, newPoint.y)
-            child.rotate = model.rotate
+        if (child) {
+          let point: Position = { x: child.x, y: child.y }
+          if (childrenPositionMap.has(child.id)) {
+            point = childrenPositionMap.get(child.id)!
+          } else {
+            childrenPositionMap.set(child.id, point)
           }
-        })
-      }
-    })
 
-    // 在 group 缩放时，对组内的所有子节点也进行对应的缩放计算
-    eventCenter.on(
-      'node:resize',
-      ({ deltaX, deltaY, index, model, preData }) => {
-        const { transformWithContainer, isRestrict } = this.props.model
-        if (!transformWithContainer || isRestrict) {
-          // isRestrict限制模式下，当前model resize时不能小于占地面积
-          // 由于parent:resize=>child:resize计算复杂，需要根据child:resize的判定结果来递归判断parent能否resize
-          // 不符合目前 parent:resize成功后emit事件 -> 触发child:resize 的代码交互模式
-          // 因此isRestrict限制模式下不支持联动(parent:resize=>child:resize)
-          return
+          // 弧度转角度
+          let theta = model.rotate * (180 / Math.PI)
+          if (theta < 0) theta += 360
+          const radian = theta * (Math.PI / 180)
+
+          const newPoint = rotatePointAroundCenter(point, center, radian)
+
+          child.moveTo(newPoint.x, newPoint.y)
+          child.rotate = model.rotate
         }
-        if (model.id === curGroup.id) {
-          // node:resize是group已经改变width和height后的回调
-          // 因此这里一定得用preData（没resize改变width之前的值），而不是data/model
-          const { properties } = preData
-          const { width: groupWidth, height: groupHeight } = properties || {}
-          forEach(Array.from(curGroup.children), (childId) => {
-            const child = graphModel.getNodeModelById(childId)
-            if (child) {
-              // 根据比例去控制缩放dx和dy
-              const childDx = (child.width / groupWidth!) * deltaX
-              const childDy = (child.height / groupHeight!) * deltaY
+      })
+    }
+  }
 
-              // child.rotate = model.rotate
-              handleResize({
-                deltaX: childDx,
-                deltaY: childDy,
-                index,
-                nodeModel: child,
-                graphModel,
-                cancelCallback: () => {},
-              })
-            }
+  onNodeResize = ({
+    deltaX,
+    deltaY,
+    index,
+    model,
+    preData,
+  }: Omit<CallbackArgs<'node:resize'>, 'e' | 'position'>) => {
+    const { model: curGroup, graphModel } = this.props
+    const { transformWithContainer, isRestrict } = curGroup
+    if (!transformWithContainer || isRestrict) {
+      // isRestrict限制模式下，当前model resize时不能小于占地面积
+      // 由于parent:resize=>child:resize计算复杂，需要根据child:resize的判定结果来递归判断parent能否resize
+      // 不符合目前 parent:resize成功后emit事件 -> 触发child:resize 的代码交互模式
+      // 因此isRestrict限制模式下不支持联动(parent:resize=>child:resize)
+      return
+    }
+    if (model.id === curGroup.id) {
+      // node:resize是group已经改变width和height后的回调
+      // 因此这里一定得用preData（没resize改变width之前的值），而不是data/model
+      const { properties } = preData
+      const { width: groupWidth, height: groupHeight } = properties || {}
+      forEach(Array.from(curGroup.children), (childId) => {
+        const child = graphModel.getNodeModelById(childId)
+        if (child) {
+          // 根据比例去控制缩放dx和dy
+          const childDx = (child.width / groupWidth!) * deltaX
+          const childDy = (child.height / groupHeight!) * deltaY
+
+          // child.rotate = model.rotate
+          handleResize({
+            deltaX: childDx,
+            deltaY: childDy,
+            index,
+            nodeModel: child,
+            graphModel,
+            cancelCallback: () => {},
           })
         }
-      },
-    )
+      })
+    }
+  }
 
+  onNodeMouseMove = ({
+    deltaX,
+    deltaY,
+    data,
+  }: Omit<CallbackArgs<'node:mousemove'>, 'e' | 'position'>) => {
+    const { model: curGroup, graphModel } = this.props
+    if (data.id === curGroup.id) {
+      const nodeIds = this.getNodesInGroup(curGroup, graphModel)
+      graphModel.moveNodes(nodeIds, deltaX, deltaY, true)
+    }
+  }
+
+  componentDidMount() {
+    super.componentDidMount()
+    const { eventCenter } = this.props.graphModel
+    // 在 group 旋转时，对组内的所有子节点也进行对应的旋转计算
+    eventCenter.on('node:rotate', this.onNodeRotate)
+    // 在 group 缩放时，对组内的所有子节点也进行对应的缩放计算
+    eventCenter.on('node:resize', this.onNodeResize)
     // 在 group 移动时，对组内的所有子节点也进行对应的移动计算
-    eventCenter.on('node:mousemove', ({ deltaX, deltaY, data }) => {
-      if (data.id === curGroup.id) {
-        const { model: curGroup, graphModel } = this.props
-        const nodeIds = this.getNodesInGroup(curGroup, graphModel)
-        graphModel.moveNodes(nodeIds, deltaX, deltaY, true)
-      }
-    })
+    eventCenter.on('node:mousemove', this.onNodeMouseMove)
   }
 
   /**

--- a/sites/docs/docs/api/eventCenter.en.md
+++ b/sites/docs/docs/api/eventCenter.en.md
@@ -29,7 +29,7 @@ flowchart. The detailed usage of events is described in [events](../tutorial/bas
 | node:delete      | Delete node                                                                                  | data                                        |
 | node:add         | Add node                                                                                     | data                                        |
 | node:dnd-add     | When a node is dragged in from outside, the node added will trigger the event                | data                                        |
-| node:dnd-drag    | When a node is dragged in from outside, the node in the dragged state will trigger the event | data                                        |
+| node:dnd-drag    | When a node is dragged in from outside, the node in the dragged state will trigger the event | data, e                                     |
 | node:dragstart   | Start dragging nodes                                                                         | data, e                                     |
 | node:drag        | Nodes in dragging                                                                            | data, e                                     |
 | node:drop        | End of node dragging                                                                         | data, e                                     |

--- a/sites/docs/docs/api/eventCenter.zh.md
+++ b/sites/docs/docs/api/eventCenter.zh.md
@@ -29,7 +29,7 @@ LogicFlow
 | node:delete      | 节点的删除       | data                                        |
 | node:add         | 节点的添加       | data                                        |
 | node:dnd-add     | 外部拖入节点添加时触发 | data                                        |
-| node:dnd-drag    | 外部拖入节点拖拽中触发 | data                                        |
+| node:dnd-drag    | 外部拖入节点拖拽中触发 | data, e                                     |
 | node:dragstart   | 节点开始拖拽      | data, e                                     |
 | node:drag        | 节点拖拽        | data, e                                     |
 | node:drop        | 节点拖拽放开      | data, e                                     |


### PR DESCRIPTION
fix [https://github.com/didi/LogicFlow/issues/1912](https://github.com/didi/LogicFlow/issues/1912)
fix [https://github.com/didi/LogicFlow/issues/1914](https://github.com/didi/LogicFlow/issues/1914)
fix [https://github.com/didi/LogicFlow/issues/1918](https://github.com/didi/LogicFlow/issues/1918)

# #1912
## 问题发生的原因

下面视频展示的关系为：dynamicGroupA嵌套dynamicGroupB，dynamicGroupB嵌套普通Node

由于dynamicGroupA嵌套dynamicGroupB，在dynamicGroupA进行折叠时，会触发dynamicGroupB的隐藏，从而触发dynamicGroupB的`componentWillUnmount()`销毁，但是如下面视频所示，dynamicGroupB的`componentDidMount()`注册了很多事件：
```ts
  componentDidMount() {
    super.componentDidMount()
    const { eventCenter } = this.props.graphModel
    // 在 group 旋转时，对组内的所有子节点也进行对应的旋转计算
    eventCenter.on('node:rotate', this.onNodeRotate)
    // 在 group 缩放时，对组内的所有子节点也进行对应的缩放计算
    eventCenter.on('node:resize', this.onNodeResize)
    // 在 group 移动时，对组内的所有子节点也进行对应的移动计算
    eventCenter.on('node:mousemove', this.onNodeMouseMove)
  }
```

但是忘记执行对应的事件移除，因此导致每一次折叠=>展开的时候，都会重复注册一次事件，因此导致下面视频所展示触发多次` moveNodes`，也就是dynamicGroupB移动1px，会触发多次它的children的`1px`移动，从而造成移动错乱问题

https://github.com/user-attachments/assets/f36d09c0-d750-4c6a-86f6-5e1117949cd1

## 解决方法

### 将componentDidMount注册的监听事件方法抽离出来，为后面解除事件监听做准备

> 提交记录：`refactor(extension): 【dynamic-group】将componentDidMount注册的监听事件方法抽离出来，为后面解除事件监听做准备`

交互逻辑无变化，只是将注册方法抽离为`this.xxxx`方法，放在外部

### componentWillUnmount移除监听

```ts
  componentWillUnmount() {
    super.componentWillUnmount()
    const { eventCenter } = this.props.graphModel
    eventCenter.off('node:rotate', this.onNodeRotate)
    eventCenter.off('node:resize', this.onNodeResize)
    eventCenter.off('node:mousemove', this.onNodeMouseMove)
  }
```

# #1914
## 问题发生的原因
在[https://github.com/didi/LogicFlow/pull/1858](https://github.com/didi/LogicFlow/pull/1858)改变了` group移动时，移动时需要同时移动组内的所有节点`的逻辑代码，原来`2.0.8`版本中的逻辑是：
```ts
graphModel.addNodeMoveRules((model, deltaX, deltaY) => {
    // 判断如果是 group，移动时需要同时移动组内的所有节点
    if (model.isGroup) {
      const nodeIds = this.getNodesInGroup(model as DynamicGroupNodeModel)
      graphModel.moveNodes(nodeIds, deltaX, deltaY, true)
      return true
    }
    //...
}
```
在`2.0.9`版本中的逻辑是
![2 0 9](https://github.com/user-attachments/assets/042d6a66-c8bc-49e4-83dc-1d6032cf01c3)

> 而为什么会出现问题呢？

是因为
- `onDragging()`->会进行坐标的处理，其中包括了`SCALE`的转化->触发addNodeMoveRules的注册的监听方法，也就是上面的`2.0.8`版本中的逻辑的`graphModel.moveNodes()`，此时的`deltaX`和`deltaY`是经过`SCALE`后的数据
- 而在在`2.0.9`版本中的`mousemove`回调是跟 `onDragging()`同时发生的，拿到的`deltaX`和`deltaY`是没有经过`SCALE`后的数据

```ts
handleMouseMove = (e: MouseEvent) => {
    //...
    Promise.resolve().then(() => {
    this.onDragging({
        deltaX,
        deltaY,
        event: e,
    })
    this.eventCenter?.emit(EventType[`${this.eventType}_MOUSEMOVE`], {
        deltaX,
        deltaY,
        e,
        data: this.data || elementData,
    })
    //...
}
```

## 解决方法

`deltaX`和`deltaY`增加`SCALE`的转化

# #1918
## 问题发生的原因

在`packages/extension/src/dynamic-group/model.ts`中有这么一段代码
```ts
setAttributes() {
    super.setAttributes()

    // 初始化时，如果 this.isCollapsed 为 true，则主动触发一次折叠操作
    if (this.isCollapsed) {
       this.toggleCollapse(true)
    }
}
```
初始化时主动触发一次折叠操作是没问题的，但是我们从`toggleCollapse`可以知道，我们是通过`elementsModelMap`去获取对应的数据，但是存在着`group已经初始化完成，但是children还没初始化的情况`，这个时候`elementsModelMap`是找不到`children`数据的
```ts
toggleCollapse(collapse?: boolean) {
    const nextCollapseState = !!collapse
    this.isCollapsed = nextCollapseState
    // step 1
    //...

    // step 2
    const childrenArr = Array.from(this.children)

    forEach(childrenArr, (elementId) => {
      // FIX: 当使用 graphModel.getElement 获取元素时，会因为
      // const model = this.graphModel.getElement(elementId)
      const model = this.graphModel.elementsModelMap.get(elementId)
      //...
    })
    // step 3
    //...
  }
```
> `group已经初始化完成，但是children还没初始化的情况`是如何发生的呢？
```ts
lf.render({
  nodes: [
    {
      type: "dynamic-group",
      x: 400,
      y: 400,
      properties: {
        children: ["rect_2"],
        isCollapsed: true,
      },
    },
    {
      id: "rect_2",
      type: "circle",
      x: 400,
      y: 400,
    },
  ],
});
```
当我们使用上面的数据进行渲染时，会触发`getModelAfterSnapToGrid()`，然后触发`group`的`new Model()`，从而触发`model.setAttributes()`->`toggleCollapse()`->使用`elementsModelMap`寻找对应的`childrenId`对应的`Model`，此时找不到`children`的`Model`，因为要等待`group`初始化好了，再执行`children`的`new Model()`，然后将`children`的`Model`放入到`elementsModelMap`中

```ts
getModelAfterSnapToGrid(node: NodeConfig) {
    //...
    const nodeModel = new Model(node, this)
    this.nodeModelMap.set(nodeModel.id, nodeModel)
    this.elementsModelMap.set(nodeModel.id, nodeModel)

    return nodeModel
}
```
因此只要把数据翻转，也就是下面的顺序，先渲染`children`->`group`，那么一切就正常了！
```ts
lf.render({
  nodes: [
    {
      id: "rect_2",
      type: "circle",
      x: 400,
      y: 400,
    },
    {
      type: "dynamic-group",
      x: 400,
      y: 400,
      properties: {
        children: ["rect_2"],
        isCollapsed: true,
      },
    },
  ],
});
```
## 解决方法

将初始化时主动触发一次折叠操作放在全部渲染完成之后再执行，也就是
![1918](https://github.com/user-attachments/assets/46dffb9a-b84a-4b2b-bc78-4183bbb7eb07)
