### PR TITLE
fix: 修复 windows 系统 node20 环境下样式文件打包失败的问题

### DIFF
--- a/scripts/build-less
+++ b/scripts/build-less
@@ -19,7 +19,7 @@ function compile(source, target) {
   if (os.type() === 'Windows_NT') {
     cmd = path.join(cwd, `${cmd}.cmd`)
   }
-  cp.execFileSync(cmd, [source, target])
+  cp.execFileSync(cmd, [source, target], { shell: true })
 }
 
 function toCSSPath(source) {


### PR DESCRIPTION
#1920

这个改动能解决 windows 系统 node20 环境下样式文件打包脚本执行报错的问题，同时不影响 node18 环境下的脚本执行，也不会影响 mac 在 node18 或 node20 下的脚本执行。