### PR TITLE
fix: 修复 node:dnd-drag 事件的类型检查问题

### DIFF
--- a/packages/core/src/event/eventArgs.ts
+++ b/packages/core/src/event/eventArgs.ts
@@ -140,7 +140,7 @@ interface NodeEventArgs {
   /**
    * 拖拽外部拖入节点
    */
-  'node:dnd-drag': NodeEventArgsPick<'data'>
+  'node:dnd-drag': NodeEventArgsPick<'data' | 'e'>
   /**
    * 开始拖拽节点
    */


### PR DESCRIPTION
前置 PR：#1916

相关 ISSUE 与 PR：#1922 #1923

忘了类型检查问题会直接导致 build 失败，这里补一下😂。