### PR TITLE
fix(example): 修复文档中vue3自定义组件不能正常显示bug

### DIFF
--- a/examples/vue3-app/src/views/LogicFlowView.vue
+++ b/examples/vue3-app/src/views/LogicFlowView.vue
@@ -88,6 +88,7 @@ const data = {
 
 const lfRef = ref<LogicFlow | null>(null)
 const containerRef = ref<HTMLDivElement | null>(null)
+const flowId = ref('')
 const TeleportContainer = getTeleport()
 
 const registerElements = (lf: LogicFlow) => {
@@ -193,6 +194,10 @@ onMounted(() => {
       },
       lf
     )
+
+    lf.on('graph:rendered', ({ graphModel }) => {
+      flowId.value = graphModel.flowId!
+    })
 
     // 注册事件
     registerEvents(lf)
@@ -433,7 +438,7 @@ const handleDragText = () => {
     </div>
     <el-divider />
     <div ref="containerRef" id="graph" class="viewport"></div>
-    <TeleportContainer />
+    <TeleportContainer :flow-id="flowId" />
   </el-card>
 </template>
 


### PR DESCRIPTION
昨天把项目拉下来想尝试使用vue3自定义组件，但是发现该组件无法正常显示
![fix1](https://github.com/user-attachments/assets/6a692a76-61c8-47eb-84b6-16786d8d3ec0)
将 flowId 传递给 TeleportContainer 之后可以修复该问题

