### PR TITLE
fix(core): 在没有拖拽的情况下，Control组件突然销毁，不触发cancelDrag(#1926)

### DIFF
--- a/packages/core/src/util/drag.ts
+++ b/packages/core/src/util/drag.ts
@@ -202,7 +202,7 @@ export class StepDrag {
     this.isDragging = false
   }
 
-  componentWillUnmount = () => {
+  destroy = () => {
     if (this.isStartDragging) {
       // https://github.com/didi/LogicFlow/issues/1934
       // https://github.com/didi/LogicFlow/issues/1926

--- a/packages/core/src/util/drag.ts
+++ b/packages/core/src/util/drag.ts
@@ -201,4 +201,16 @@ export class StepDrag {
     this.onDragEnd({ event: undefined })
     this.isDragging = false
   }
+
+  componentWillUnmount = () => {
+    if (this.isStartDragging) {
+      // https://github.com/didi/LogicFlow/issues/1934
+      // https://github.com/didi/LogicFlow/issues/1926
+      // cancelDrag()->onDragEnd()->updateEdgePointByAnchors()触发线的重新计算
+      // 我们的本意是为了防止mousemove和mouseup没有及时被移除
+      // 因此这里增加if(this.isStartDragging)的判断，isStartDragging=true代表没有触发handleMouseUp()，此时监听还没被移除
+      // 在拖拽情况下(isStartDragging=true)，此时注册了监听，在组件突然销毁时，强制触发cancelDrag进行监听事件的移除
+      this.cancelDrag()
+    }
+  }
 }

--- a/packages/core/src/view/Control.tsx
+++ b/packages/core/src/view/Control.tsx
@@ -57,7 +57,7 @@ export class ResizeControl extends Component<
   }
 
   componentWillUnmount() {
-    this.dragHandler.cancelDrag()
+    this.dragHandler.componentWillUnmount()
   }
 
   updateEdgePointByAnchors = () => {

--- a/packages/core/src/view/Control.tsx
+++ b/packages/core/src/view/Control.tsx
@@ -57,7 +57,7 @@ export class ResizeControl extends Component<
   }
 
   componentWillUnmount() {
-    this.dragHandler.componentWillUnmount()
+    this.dragHandler.destroy()
   }
 
   updateEdgePointByAnchors = () => {


### PR DESCRIPTION
fix [https://github.com/didi/LogicFlow/issues/1934](https://github.com/didi/LogicFlow/issues/1934)
fix [https://github.com/didi/LogicFlow/issues/1926](https://github.com/didi/LogicFlow/issues/1926)

## 问题发生的原因

为了解决`Control`组件意外销毁，但是没有及时释放监听事件的问题，在组件销毁时，强制触发了
```ts
  componentWillUnmount() {
    this.dragHandler.cancelDrag()
  }
```
这导致一个问题
- 用户点击node，会显示出`Control`组件，点击空白地方会隐藏`Control`组件，从而触发`componentWillUnmount`，从而触发cancelDrag()->onDragEnd()->updateEdgePointByAnchors()触发线的重新计算
- 用户经过node，然后离开node，也会触发触发`componentWillUnmount`，从而触发cancelDrag()->onDragEnd()->updateEdgePointByAnchors()触发线的重新计算

自动触发计算逻辑一直存在，但是一般是拖拽时才会触发，用户也能理解这个逻辑

但是目前这个组件销毁时就触发一次自动触发计算会给用户造成一种bug的错觉

## 解决方法

我们的本意是为了防止`mousemove`和`mouseup`没有及时被移除，如下面所示，在触发`handleMouseDown`时，会注册监听，在`handleMouseUp`时，会解除监听

```ts
handleMouseDown = (e: MouseEvent) => {
  const DOC: any = window?.document;
  if (e.button !== LEFT_MOUSE_BUTTON_CODE) return;
  if (this.isStopPropagation) e.stopPropagation();
  this.isStartDragging = true;
  //...
  DOC.addEventListener('mousemove', this.handleMouseMove, false)
  DOC.addEventListener('mouseup', this.handleMouseUp, false)
};

handleMouseUp = (e: MouseEvent) => {
  const DOC = window.document;

  this.isStartDragging = false;
  if (this.isStopPropagation) e.stopPropagation();
  // fix #568: 如果onDragging在下一个事件循环中触发，而drop在当前事件循环，会出现问题。
  Promise.resolve().then(() => {
    DOC.removeEventListener("mousemove", this.handleMouseMove, false);
    DOC.removeEventListener("mouseup", this.handleMouseUp, false);
    //...
  });
};

```
因此这里增加`if(this.isStartDragging)`的判断，`isStartDragging=true`代表没有触发`handleMouseUp()`，此时监听还没被移除；在拖拽情况下(isStartDragging=true)，在组件突然销毁时，强制触发`cancelDrag()`进行监听事件的移除
```ts
// packages/core/src/util/drag.ts
destroy = () => {
  if (this.isStartDragging) {
    this.cancelDrag();
  }
};
```