### PR TITLE
fix(core): 修复 polyline 与多边形节点的交点不正确的问题

### DIFF
--- a/packages/core/__tests__/algorithm/egde.test.ts
+++ b/packages/core/__tests__/algorithm/egde.test.ts
@@ -1,4 +1,4 @@
-import { getCrossPointOfLine, isInSegment } from '../../src/algorithm/edge';
+import { getCrossPointOfLine, isInSegment } from '../../src/algorithm/edge'
 
 describe('algorithm/edge', () => {
   // one intersection
@@ -12,7 +12,7 @@ describe('algorithm/edge', () => {
         x: 10,
         y: 10,
       },
-    ];
+    ]
     const line2 = [
       {
         x: 10,
@@ -22,11 +22,11 @@ describe('algorithm/edge', () => {
         x: 0,
         y: 10,
       },
-    ];
+    ]
     expect(
       getCrossPointOfLine(line1[0], line1[1], line2[0], line2[1]),
-    ).toBeTruthy();
-  });
+    ).toBeTruthy()
+  })
   // multiple intersection
   test('multiple intersection', () => {
     const line1 = [
@@ -38,7 +38,7 @@ describe('algorithm/edge', () => {
         x: 10,
         y: 10,
       },
-    ];
+    ]
     const line2 = [
       {
         x: 0,
@@ -48,11 +48,11 @@ describe('algorithm/edge', () => {
         x: 10,
         y: 10,
       },
-    ];
+    ]
     expect(
       getCrossPointOfLine(line1[0], line1[1], line2[0], line2[1]),
-    ).toBeFalsy();
-  });
+    ).toBeFalsy()
+  })
   // no intersection
   test('intersection', () => {
     const line1 = [
@@ -64,7 +64,7 @@ describe('algorithm/edge', () => {
         x: 10,
         y: 10,
       },
-    ];
+    ]
     const line2 = [
       {
         x: 10,
@@ -74,18 +74,18 @@ describe('algorithm/edge', () => {
         x: 20,
         y: 10,
       },
-    ];
+    ]
     expect(
       getCrossPointOfLine(line1[0], line1[1], line2[0], line2[1]),
-    ).toBeFalsy();
-  });
+    ).toBeFalsy()
+  })
 
   test('in segment', () => {
     const point = {
       x: 0,
       y: 0,
-    };
-    const line = [
+    }
+    const line1 = [
       {
         x: -10,
         y: -10,
@@ -94,15 +94,28 @@ describe('algorithm/edge', () => {
         x: 10,
         y: 10,
       },
-    ];
-    expect(isInSegment(point, line[0], line[1])).toBeTruthy();
-  });
+    ]
+    const line2 = [
+      {
+        x: -10,
+        y: 10,
+      },
+      {
+        x: 10,
+        y: -10,
+      },
+    ]
+    expect(isInSegment(point, line1[0], line2[1])).toBeTruthy()
+    expect(isInSegment(point, line1[1], line2[0])).toBeTruthy()
+    expect(isInSegment(point, line2[0], line1[1])).toBeTruthy()
+    expect(isInSegment(point, line2[1], line1[0])).toBeTruthy()
+  })
   // not in segment
   test('not in segment', () => {
     const point = {
       x: 10,
       y: 0,
-    };
+    }
     const line = [
       {
         x: -10,
@@ -112,7 +125,7 @@ describe('algorithm/edge', () => {
         x: 10,
         y: 10,
       },
-    ];
-    expect(isInSegment(point, line[0], line[1])).toBeFalsy();
-  });
-});
+    ]
+    expect(isInSegment(point, line[0], line[1])).toBeFalsy()
+  })
+})

--- a/packages/core/src/algorithm/edge.ts
+++ b/packages/core/src/algorithm/edge.ts
@@ -60,10 +60,8 @@ export const isInSegment = (point: Point, start: Point, end: Point) => {
   const k = (endY - startY) / (endX - startX)
   const b = startY - k * startX
   return (
-    x >= startX &&
-    x <= endX &&
-    y >= startY &&
-    y <= endY &&
+    ((x >= startX && x <= endX) || (x <= startX && x >= endX)) &&
+    ((y >= startY && y <= endY) || (y <= startY && y >= endY)) &&
     Math.abs(y - k * x + b) < Number.EPSILON
   )
 }


### PR DESCRIPTION

修改了下面这个算法。这个算法只考虑到了endPoint的x,y均比startPoint的x,y大的情况，逻辑不严谨，从而间接导致了polyline与多边形的交点位置与预期不符
https://github.com/didi/LogicFlow/blob/e9f097c1532874c83c14ffefe01215e3be8bb278/packages/core/src/algorithm/edge.ts#L52-L69

详见：https://github.com/didi/LogicFlow/issues/1945#issuecomment-2456765882
