### PR TITLE
fix(core): 修复因算法错误导致 polyline 与多边形节点的交点不正确的问题

### DIFF
--- a/packages/core/__tests__/algorithm/egde.test.ts
+++ b/packages/core/__tests__/algorithm/egde.test.ts
@@ -105,10 +105,10 @@ describe('algorithm/edge', () => {
         y: -10,
       },
     ]
-    expect(isInSegment(point, line1[0], line2[1])).toBeTruthy()
-    expect(isInSegment(point, line1[1], line2[0])).toBeTruthy()
-    expect(isInSegment(point, line2[0], line1[1])).toBeTruthy()
-    expect(isInSegment(point, line2[1], line1[0])).toBeTruthy()
+    expect(isInSegment(point, line1[0], line1[1])).toBeTruthy()
+    expect(isInSegment(point, line1[1], line1[0])).toBeTruthy()
+    expect(isInSegment(point, line2[0], line2[1])).toBeTruthy()
+    expect(isInSegment(point, line2[1], line2[0])).toBeTruthy()
   })
   // not in segment
   test('not in segment', () => {

--- a/packages/core/src/algorithm/edge.ts
+++ b/packages/core/src/algorithm/edge.ts
@@ -62,6 +62,6 @@ export const isInSegment = (point: Point, start: Point, end: Point) => {
   return (
     ((x >= startX && x <= endX) || (x <= startX && x >= endX)) &&
     ((y >= startY && y <= endY) || (y <= startY && y >= endY)) &&
-    Math.abs(y - k * x + b) < Number.EPSILON
+    Math.abs(y - k * x - b) < Number.EPSILON
   )
 }


### PR DESCRIPTION
上个pr漏改了: https://github.com/didi/LogicFlow/pull/1947#issue-2635191196
https://github.com/didi/LogicFlow/blob/e9f097c1532874c83c14ffefe01215e3be8bb278/packages/core/src/algorithm/edge.ts#L67

其中 `y - k * x + b` 应该改成 `y - k * x - b`