### PR TITLE
修复 DynamicGroup 相关 bug

### DIFF
--- a/packages/core/src/event/eventArgs.ts
+++ b/packages/core/src/event/eventArgs.ts
@@ -132,7 +132,7 @@ interface NodeEventArgs {
   /**
    * 删除节点
    */
-  'node:delete': NodeEventArgsPick<'data'>
+  'node:delete': NodeEventArgsPick<'data' | 'model'>
   /**
    * 添加外部拖入节点
    */

--- a/packages/core/src/model/GraphModel.ts
+++ b/packages/core/src/model/GraphModel.ts
@@ -749,11 +749,15 @@ export class GraphModel {
    */
   @action
   deleteNode(nodeId: string) {
-    const nodeData = this.nodesMap[nodeId].model.getData()
+    const nodeModel = this.nodesMap[nodeId].model
+    const nodeData = nodeModel.getData()
     this.deleteEdgeBySource(nodeId)
     this.deleteEdgeByTarget(nodeId)
     this.nodes.splice(this.nodesMap[nodeId].index, 1)
-    this.eventCenter.emit(EventType.NODE_DELETE, { data: nodeData })
+    this.eventCenter.emit(EventType.NODE_DELETE, {
+      data: nodeData,
+      model: nodeModel,
+    })
   }
 
   /**

--- a/packages/extension/src/dynamic-group/index.ts
+++ b/packages/extension/src/dynamic-group/index.ts
@@ -240,8 +240,11 @@ export class DynamicGroup {
     }
   }
 
-  removeNodeFromGroup = ({ data: node }: CallbackArgs<'node:delete'>) => {
-    if (node.isGroup && node.children) {
+  removeNodeFromGroup = ({
+    data: node,
+    model,
+  }: CallbackArgs<'node:delete'>) => {
+    if (model.isGroup && node.children) {
       forEach(
         Array.from((node as DynamicGroupNodeModel).children),
         (childId) => {

--- a/packages/extension/src/dynamic-group/index.ts
+++ b/packages/extension/src/dynamic-group/index.ts
@@ -86,7 +86,9 @@ export class DynamicGroup {
     } else {
       let topZIndexGroup = groups[count - 1]
       for (let i = count - 2; i >= 0; i--) {
-        topZIndexGroup = groups[i]
+        if (groups[i].zIndex > topZIndexGroup.zIndex) {
+          topZIndexGroup = groups[i]
+        }
       }
       return topZIndexGroup as DynamicGroupNodeModel
     }


### PR DESCRIPTION
## 修复 DynamicGroup 被删除时其内部节点没有一起删除的 bug
DynamicGroup 的 removeNodeFromGroup 方法判断是否是分组节点需要从 model 里获取，data 里没有 isGroup 属性，导致删除子节点的代码无效。
修改为在删除节点触发事件时额外传递 model 参数，用 model 的 isGroup 进行判断。

原行为：
![chrome-capture-2024-11-12](https://github.com/user-attachments/assets/05952ed6-3cf0-47cf-80b8-becf5d44a34e)

修改后：
![chrome-capture-2024-11-12 (2)](https://github.com/user-attachments/assets/4ba7a33c-38d0-45eb-9d37-6fbaadd0f019)

## 修复 DynamicGroup 多层嵌套时移入节点归属异常
之前 DynamicGroup getGroupByBounds 中缺失 zIndex 的判断逻辑
参考旧的 Group 组件的 getGroup 方法中的处理添加了对 zIndex 的判断

原行为：
![chrome-capture-2024-11-12 (5)](https://github.com/user-attachments/assets/5759d9a4-b434-458d-8487-711dc804f359)
修改后：
![chrome-capture-2024-11-12 (4)](https://github.com/user-attachments/assets/66b09447-b754-4a97-97d2-ea98fe744803)

