### PR TITLE
feat: 增加业务场景示例

### DIFF
--- a/sites/docs/examples/showcase/bussiness/demo/meta.json
+++ b/sites/docs/examples/showcase/bussiness/demo/meta.json
@@ -74,6 +74,17 @@
       "screenshot": "https://cdn.jsdelivr.net/gh/Logic-Flow/static@latest/docs/examples/case/bussiness/organizer.png",
       "previewUrl": "https://examples.logic-flow.cn/demo/dist/organizer",
       "githubUrl": "https://github.com/Logic-Flow/docs/tree/master/demo/organizer"
+    },
+    {
+      "filename": "profileEditor.tsx",
+      "isExternal": true,
+      "title": {
+        "zh": "配置文件编辑器",
+        "en": "Instrument Profile Editor"
+      },
+      "screenshot": "https://cdn.jsdelivr.net/gh/Logic-Flow/static@latest/docs/examples/case/bussiness/automation.jpg",
+      "previewUrl": "https://instrument-profile-editor.hisoten.xyz/",
+      "githubUrl": "https://github.com/ChangeSuger/instrument-profile-editor"
     }
   ]
 }


### PR DESCRIPTION
增加一个业务场景示例——基于 LogicFlow 实现的[仪器配置文件编辑器](https://instrument-profile-editor.hisoten.xyz/)。

该项目用于支持仪器配置文件的图形化编辑，在该业务场景下，配置文件的嵌套层级固定为四层，非常适合用类似脑图的编辑方式来支持图形化编辑。