### PR TITLE
fix: 修复设置 textDraggable 为 true 时，边、节点文本无法拖拽的 bug

### DIFF
--- a/examples/feature-examples/src/pages/graph/index.tsx
+++ b/examples/feature-examples/src/pages/graph/index.tsx
@@ -22,6 +22,8 @@ const config: Partial<LogicFlow.Options> = {
   isSilentMode: false,
   stopScrollGraph: true,
   stopZoomGraph: true,
+  // textDraggable: true, // TODO: 节点旋转状态下，拖动文本移动是有问题的！！！
+  edgeTextDraggable: true,
   style: {
     rect: {
       rx: 5,

--- a/packages/core/src/model/edge/BaseEdgeModel.ts
+++ b/packages/core/src/model/edge/BaseEdgeModel.ts
@@ -515,14 +515,17 @@ export class BaseEdgeModel<P extends PropertiesType = PropertiesType>
    * 内部方法，处理初始化文本格式
    */
   @action formatText(data: EdgeConfig) {
+    const {
+      editConfigModel: { edgeTextDraggable, edgeTextEdit },
+    } = this.graphModel
     const { x, y } = this.textPosition
     const { text } = data
     let textConfig: Required<TextConfig> = {
       value: '',
       x,
       y,
-      draggable: false,
-      editable: true,
+      draggable: edgeTextDraggable,
+      editable: edgeTextEdit,
     }
 
     if (text) {

--- a/packages/core/src/model/node/BaseNodeModel.ts
+++ b/packages/core/src/model/node/BaseNodeModel.ts
@@ -246,13 +246,16 @@ export class BaseNodeModel<P extends PropertiesType = PropertiesType>
    * 始化文本属性
    */
   private formatText(data: NodeConfig): void {
+    const {
+      editConfigModel: { nodeTextDraggable, nodeTextEdit },
+    } = this.graphModel
     const { x, y, text } = data
     let textConfig: TextConfig = {
       value: '',
       x,
       y,
-      draggable: false,
-      editable: true,
+      draggable: nodeTextDraggable,
+      editable: nodeTextEdit,
     }
     if (text) {
       if (typeof text === 'string') {


### PR DESCRIPTION
 - 初始化节点、边时，draggable 和 editable 属性由默认值更新为使用 editConfigModel 中的值