### PR TITLE
fix(docs): 修复文档中“基础教程”和“实例”部分的 `nodeModel` 和 `edgeModel` 跳转地址错误

### DIFF
--- a/sites/docs/docs/tutorial/basic/class.en.md
+++ b/sites/docs/docs/tutorial/basic/class.en.md
@@ -43,10 +43,10 @@ following data structure to represent the graph data of LogicFlow.
 <code id="graphData" src="../../../src/tutorial/basic/instance/graphData"></code>
 
 **`nodes`**: Contains all nodes. Each node's data attributes are detailed in
-the <a href="../api/nodeModelApi.en.md#DataAttributes">nodeModel</a>.
+the <a href="../../../en/api/model/node-model#DataAttributes">nodeModel</a>.
 
 **`edges`**: Contains all edges, connecting two nodes through `sourceNodeId` and `targetNodeId`.
-Each edge's data attributes are detailed in the <a href="../api/edgeModelApi.en.md#DataAttributes">
+Each edge's data attributes are detailed in the <a href="../../../en/api/model/edge-model#DataAttributes">
 EdgeModel</a>.
 
 **`type`**: Indicates the type of node or edge, which can be a basic type built into LogicFlow such

--- a/sites/docs/docs/tutorial/basic/class.zh.md
+++ b/sites/docs/docs/tutorial/basic/class.zh.md
@@ -40,11 +40,11 @@ const lf = new LogicFlow({
 
 <code id="graphData" src="../../../src/tutorial/basic/instance/graphData"></code>
 
-**`nodes`**: 包含所有的节点。每个节点的数据属性详见 <a href="../api/nodeModelApi#数据属性">
+**`nodes`**: 包含所有的节点。每个节点的数据属性详见 <a href="../../api/model/node-model#数据属性">
 nodeModel</a> 。
 
 **`edges`**: 包含所有的边，通过起始 `sourceNodeId` 和 `targetNodeId`
-将两个节点相连。每个边的数据属性详见  <a href="../api/edgeModelApi#数据属性">edgeModel</a>。
+将两个节点相连。每个边的数据属性详见  <a href="../../api/model/edge-model#数据属性">edgeModel</a>。
 
 **`type`**: 表示节点或者边的类型，这里的类型不仅可以是`rect`,`polyline`
 这种LogicFlow内置的基础类型，也可以是用户基于基础类型自定义的类型。


### PR DESCRIPTION
在使用 LogicFlow时，我发现基础教程中的实例文档中，关于节点和边的属性链接存在跳转失败的问题。 [地址](https://site.logic-flow.cn/tutorial/basic/class)

![跳转问题](https://github.com/user-attachments/assets/89566b9a-3ff1-4e54-8288-ec3a53e2956b)
