### PR TITLE
fix(extension): 【dynamic-group】DynamicGroup 使用 moveNode 进行移动时子节点没有跟随移动 

### DIFF
--- a/examples/engine-browser-examples/src/pages/extension/dynamic-group/index.tsx
+++ b/examples/engine-browser-examples/src/pages/extension/dynamic-group/index.tsx
@@ -87,6 +87,24 @@ export default function DynamicGroupDemo() {
         ...config,
         container: containerRef.current as HTMLElement,
       })
+      ;(lf.extension.control as Control).addItem({
+        key: 'move-group',
+        iconClass: 'custom-minimap',
+        title: '',
+        text: '右移分组',
+        onClick: (lf) => {
+          const { nodes } = lf.getSelectElements()
+          const selectedNode = nodes[0]
+          if (!selectedNode) {
+            return
+          }
+          const isGroup = lf.getModelById(selectedNode.id)?.isGroup
+          if (!isGroup) {
+            return
+          }
+          lf.graphModel.moveNode(selectedNode.id, 10, 0)
+        },
+      })
 
       const dndPanelConfig = getDndPanelConfig(lf)
       lf.setPatternItems(dndPanelConfig)

--- a/packages/extension/src/components/selection-select/index.ts
+++ b/packages/extension/src/components/selection-select/index.ts
@@ -166,18 +166,20 @@ export class SelectionSelect {
         true,
       )
       const { dynamicGroup, group } = this.lf.graphModel
+      const nonGroupedElements: typeof elements = []
       elements.forEach((element) => {
         // 如果节点属于分组，则不选中节点，此处兼容旧版 Group 插件
-        if (!group || !group.getNodeGroup(element.id)) {
-          this.lf.selectElementById(element.id, true)
+        if (group && group.getNodeGroup(element.id)) {
+          return
         }
-        // 如果节点属于动态分组，则不不选中节点
-        if (!dynamicGroup || !dynamicGroup.getGroupByNodeId(element.id)) {
-          this.lf.selectElementById(element.id, true)
+        if (dynamicGroup && dynamicGroup.getGroupByNodeId(element.id)) {
+          return
         }
+        this.lf.selectElementById(element.id, true)
+        nonGroupedElements.push(element)
       })
       this.lf.emit('selection:selected', {
-        elements,
+        elements: nonGroupedElements,
         leftTopPoint: lt,
         rightBottomPoint: rb,
       })

--- a/packages/extension/src/dynamic-group/model.ts
+++ b/packages/extension/src/dynamic-group/model.ts
@@ -185,24 +185,11 @@ export class DynamicGroupNodeModel extends RectNodeModel<IGroupNodeProperties> {
    * 获取分组内的节点
    * @param groupModel
    */
-  getNodesInGroup(
-    groupModel: DynamicGroupNodeModel,
-    graphModel: GraphModel,
-  ): string[] {
-    let nodeIds: string[] = []
+  getNodesInGroup(groupModel: DynamicGroupNodeModel): string[] {
+    const nodeIds: string[] = []
     if (groupModel.isGroup) {
       forEach(Array.from(groupModel.children), (nodeId: string) => {
         nodeIds.push(nodeId)
-
-        const nodeModel = graphModel.getNodeModelById(nodeId)
-        if (nodeModel?.isGroup) {
-          nodeIds = nodeIds.concat(
-            this.getNodesInGroup(
-              nodeModel as DynamicGroupNodeModel,
-              graphModel,
-            ),
-          )
-        }
       })
     }
     return nodeIds
@@ -217,7 +204,7 @@ export class DynamicGroupNodeModel extends RectNodeModel<IGroupNodeProperties> {
       deltaY,
       isIgnoreRule,
     )
-    const nodeIds = this.getNodesInGroup(this, this.graphModel)
+    const nodeIds = this.getNodesInGroup(this)
     this.graphModel.moveNodes(nodeIds, deltaX, deltaY, isIgnoreRule)
     return [moveDeltaX, moveDeltaY]
   }

--- a/packages/extension/src/dynamic-group/model.ts
+++ b/packages/extension/src/dynamic-group/model.ts
@@ -182,6 +182,47 @@ export class DynamicGroupNodeModel extends RectNodeModel<IGroupNodeProperties> {
   }
 
   /**
+   * 获取分组内的节点
+   * @param groupModel
+   */
+  getNodesInGroup(
+    groupModel: DynamicGroupNodeModel,
+    graphModel: GraphModel,
+  ): string[] {
+    let nodeIds: string[] = []
+    if (groupModel.isGroup) {
+      forEach(Array.from(groupModel.children), (nodeId: string) => {
+        nodeIds.push(nodeId)
+
+        const nodeModel = graphModel.getNodeModelById(nodeId)
+        if (nodeModel?.isGroup) {
+          nodeIds = nodeIds.concat(
+            this.getNodesInGroup(
+              nodeModel as DynamicGroupNodeModel,
+              graphModel,
+            ),
+          )
+        }
+      })
+    }
+    return nodeIds
+  }
+  getMoveDistance(
+    deltaX: number,
+    deltaY: number,
+    isIgnoreRule = false,
+  ): [number, number] {
+    const [moveDeltaX, moveDeltaY] = super.getMoveDistance(
+      deltaX,
+      deltaY,
+      isIgnoreRule,
+    )
+    const nodeIds = this.getNodesInGroup(this, this.graphModel)
+    this.graphModel.moveNodes(nodeIds, deltaX, deltaY, isIgnoreRule)
+    return [moveDeltaX, moveDeltaY]
+  }
+
+  /**
    * 重写 getHistoryData 方法
    */
   getHistoryData(): NodeData {

--- a/packages/extension/src/dynamic-group/model.ts
+++ b/packages/extension/src/dynamic-group/model.ts
@@ -194,6 +194,7 @@ export class DynamicGroupNodeModel extends RectNodeModel<IGroupNodeProperties> {
     }
     return nodeIds
   }
+
   getMoveDistance(
     deltaX: number,
     deltaY: number,

--- a/packages/extension/src/dynamic-group/node.ts
+++ b/packages/extension/src/dynamic-group/node.ts
@@ -106,24 +106,27 @@ export class DynamicGroupNode<
     }
   }
 
-  onNodeMouseMove = ({
-    deltaX,
-    deltaY,
-    data,
-  }: Omit<CallbackArgs<'node:mousemove'>, 'e' | 'position'>) => {
-    const { model: curGroup, graphModel } = this.props
-    const { transformModel } = graphModel
-    const { SCALE_X, SCALE_Y } = transformModel
-    if (data.id === curGroup.id) {
-      const nodeIds = this.getNodesInGroup(curGroup, graphModel)
-      // https://github.com/didi/LogicFlow/issues/1914
-      // 当调用lf.fitView()时，会改变整体的SCALE_X和SCALE_Y
-      // 由于group的mousemove是在drag.ts的this.onDragging()处理的，在onDragging()里面进行SCALE的处理
-      // 而"node:mousemove"emit出来跟onDragging()是同时的，也就是emit出来的数据是没有经过SCALE处理的坐标
-      // 因此这里需要增加SCALE的处理
-      graphModel.moveNodes(nodeIds, deltaX / SCALE_X, deltaY / SCALE_Y, true)
+  onNodeMouseMove = () =>
+    // {
+    // deltaX,
+    // deltaY,
+    // data,
+    // }: Omit<CallbackArgs<'node:mousemove'>, 'e' | 'position'>
+    {
+      // console.log(data,deltaX,deltaY,'111')
+      // const { model: curGroup, graphModel } = this.props
+      // const { transformModel } = graphModel
+      // const { SCALE_X, SCALE_Y } = transformModel
+      // if (data.id === curGroup.id) {
+      //   const nodeIds = this.getNodesInGroup(curGroup, graphModel)
+      //   // https://github.com/didi/LogicFlow/issues/1914
+      //   // 当调用lf.fitView()时，会改变整体的SCALE_X和SCALE_Y
+      //   // 由于group的mousemove是在drag.ts的this.onDragging()处理的，在onDragging()里面进行SCALE的处理
+      //   // 而"node:mousemove"emit出来跟onDragging()是同时的，也就是emit出来的数据是没有经过SCALE处理的坐标
+      //   // 因此这里需要增加SCALE的处理
+      //   graphModel.moveNodes(nodeIds, deltaX / SCALE_X, deltaY / SCALE_Y, true)
+      // }
     }
-  }
 
   graphRendered = () => {
     const { model } = this.props

--- a/packages/extension/src/dynamic-group/node.ts
+++ b/packages/extension/src/dynamic-group/node.ts
@@ -172,6 +172,7 @@ export class DynamicGroupNode<
   /**
    * 获取分组内的节点
    * @param groupModel
+   * @param graphModel
    */
   getNodesInGroup(
     groupModel: DynamicGroupNodeModel,


### PR DESCRIPTION
在 https://github.com/didi/LogicFlow/pull/1858 中，分组内节点跟随移动的逻辑被放在了 node:mousemove 事件监听中，导致只有拖拽才会触发该逻辑。对分组使用 Api 如 moveNode 时，不会触发这个事件，子节点不跟随。
现将跟随移到逻辑改到 getMoveDistance 中，拖拽和使用方法进行移动时均会执行该方法。

同时，selection-select 插件中有问题，在选择到分组节点时，会将子节点也选中，导致在做了上面的修改后，子节点会移动 n 次。
selection-select 的代码里有对分组情况的处理：
```JavaScript
        // 如果节点属于分组，则不选中节点，此处兼容旧版 Group 插件
        if (!group || !group.getNodeGroup(element.id)) {
          this.lf.selectElementById(element.id, true)
        }
        // 如果节点属于动态分组，则不不选中节点
        if (!dynamicGroup || !dynamicGroup.getGroupByNodeId(element.id)) {
          this.lf.selectElementById(element.id, true)
        }
```
这样的判断在单独使用分组插件时，会有另一个 if 触发，选中节点。现在修复了该逻辑，不会影响到分组的移动

效果：
![chrome-capture-2024-11-15](https://github.com/user-attachments/assets/ef28695f-5237-4d7e-bb66-4aafbb3fc581)

这样处理后也能修复 #1949  ，这种场景下，鼠标没有移动，所以不触发事件
效果：
![chrome-capture-2024-11-15 (1)](https://github.com/user-attachments/assets/9c8b7d29-290a-4a72-9387-d8b42ef88fca)
