### PR TITLE
fix(core): 修复节点旋转后锚点无法被接线的问题

### DIFF
--- a/packages/core/src/util/node.ts
+++ b/packages/core/src/util/node.ts
@@ -13,6 +13,7 @@ import {
 } from '../model'
 import { SegmentDirection } from '../constant'
 import { isInSegment } from '../algorithm/edge'
+import { Matrix } from './matrix'
 
 import Point = LogicFlow.Point
 import Direction = LogicFlow.Direction
@@ -112,33 +113,33 @@ export const distance = (
 ): number => Math.hypot(x1 - x2, y1 - y2)
 
 /* 是否在某个节点内，手否进行连接，有offset控制粒度，与outline有关，可以优化 */
-export const isInNode = (position: Point, node: BaseNodeModel): boolean => {
+export const isInNode = (
+  position: Point,
+  node: BaseNodeModel,
+  offset = 0,
+): boolean => {
   let inNode = false
-  const offset = 0
   const bBox = getNodeBBox(node)
+  const [x, y] = new Matrix([position.x, position.y, 1])
+    .translate(-node.x, -node.y)
+    .rotate(-node.rotate)
+    .translate(node.x, node.y)[0]
+  const reverseRotatedPosition = {
+    x,
+    y,
+  }
   if (
-    position.x >= bBox.minX - offset &&
-    position.x <= bBox.maxX + offset &&
-    position.y >= bBox.minY - offset &&
-    position.y <= bBox.maxY + offset
+    reverseRotatedPosition.x >= bBox.minX - offset &&
+    reverseRotatedPosition.x <= bBox.maxX + offset &&
+    reverseRotatedPosition.y >= bBox.minY - offset &&
+    reverseRotatedPosition.y <= bBox.maxY + offset
   ) {
     inNode = true
   }
   return inNode
 }
 export const isInNodeBbox = (position: Point, node: BaseNodeModel): boolean => {
-  let inNode = false
-  const offset = 5
-  const bBox = getNodeBBox(node)
-  if (
-    position.x >= bBox.minX - offset &&
-    position.x <= bBox.maxX + offset &&
-    position.y >= bBox.minY - offset &&
-    position.y <= bBox.maxY + offset
-  ) {
-    inNode = true
-  }
-  return inNode
+  return isInNode(position, node, 5)
 }
 
 export type NodeBBox = {


### PR DESCRIPTION
isInNodeBbox 没处理旋转的场景，用的是旋转前的 bBox 进行判断。现将用于判断的点反向旋转后再进行判断

另外 `isInNode` 和 `isInNodeBbox` 只有 offset 不同，合并了两个方法

close #1871

before: 
![chrome-capture-2024-12-13](https://github.com/user-attachments/assets/d26bf670-72bf-43bb-904a-ada485e9e1bb)

after:
![chrome-capture-2024-12-13 (1)](https://github.com/user-attachments/assets/3c9936b4-5add-4cfe-9471-c1275cbc98be)

