### PR TITLE
fix: 修复调整窗口大小后，小地图插件表现异常的问题

### DIFF
--- a/packages/extension/src/style/index.less
+++ b/packages/extension/src/style/index.less
@@ -221,6 +221,11 @@
   border: 1px solid #93a3b4;
 }
 
+.lf-mini-map .lf-graph {
+  width: 100% !important;
+  height: 100% !important;
+}
+
 .lf-mini-map-graph {
   position: relative;
   overflow: hidden;


### PR DESCRIPTION
close #2017 

> 目前这个 bug 可以直接在 [MiniMap Demo](https://site.logic-flow.cn/examples/extension/native#miniMap) 上复现（可能需要较大幅度的拖动小地图元素来触发）。

基于父元素实际大小调整 LF 画布大小的操作与 MiniMap 的实现有冲突，这里强制覆盖了一下样式，不会对其他功能有影响。