### PR TITLE
fix(core): 修复多选旋转的节点后进行移动时，节点位置异常问题

### DIFF
--- a/packages/core/src/model/node/BaseNodeModel.ts
+++ b/packages/core/src/model/node/BaseNodeModel.ts
@@ -740,6 +740,10 @@ export class BaseNodeModel<P extends PropertiesType = PropertiesType>
       this.text && this.moveText(0, deltaY)
       moveY = deltaY
     }
+    this.transform = new TranslateMatrix(-this.x, -this.y)
+      .rotate(this.rotate)
+      .translate(this.x, this.y)
+      .toString()
     return [moveX, moveY]
   }
 

--- a/packages/core/src/view/node/BaseNode.tsx
+++ b/packages/core/src/view/node/BaseNode.tsx
@@ -13,7 +13,6 @@ import {
   isMultipleSelect,
   cancelRaf,
   createRaf,
-  TranslateMatrix,
   IDragParams,
   // RotateMatrix,
 } from '../../util'
@@ -296,11 +295,6 @@ export abstract class BaseNode<P extends IProps = IProps> extends Component<
     if (this.t) {
       cancelRaf(this.t)
     }
-
-    model.transform = new TranslateMatrix(-x, -y)
-      .rotate(model.rotate)
-      .translate(x, y)
-      .toString()
 
     let moveNodes = selectNodes.map((node) => node.id)
     // 未被选中的节点也可以拖动


### PR DESCRIPTION
多选时的移动未更新 transform 导致旋转的节点位置异常。改成在 getMoveDistance 方法中更新 transform，统一处理所有移动逻辑

before:
![chrome-capture-2025-1-2](https://github.com/user-attachments/assets/33e60fa0-b847-4cdd-8cfd-22da9d910fe3)

after:
![chrome-capture-2025-1-2 (1)](https://github.com/user-attachments/assets/4707e2aa-dd9a-4e18-bf85-1c4fa9dcbd35)
