### PR TITLE
修复未选中节点时进行快速缩放会退出缩放

### DIFF
--- a/packages/core/src/view/Control.tsx
+++ b/packages/core/src/view/Control.tsx
@@ -50,6 +50,7 @@ export class ResizeControl extends Component<
 
     // 初始化拖拽工具
     this.dragHandler = new StepDrag({
+      onDragStart: this.onDragStart,
       onDragging: this.onDragging,
       onDragEnd: this.onDragEnd,
       step: graphModel.gridSize,
@@ -315,6 +316,10 @@ export class ResizeControl extends Component<
     // this.updateEdgePointByAnchors()
     // // 触发 resize 事件
     // this.triggerResizeEvent(preNodeData, curNodeData, deltaX, deltaY, this.index, this.nodeModel)
+  }
+
+  onDragStart = () => {
+    this.graphModel.selectNodeById(this.nodeModel.id)
   }
 
   onDragging = ({ deltaX, deltaY }: IDragParams) => {


### PR DESCRIPTION
当未选中节点时，节点的ResizeControl只有在hover时才启用，当快速缩放时，节点的大小可能会跟不上鼠标导致不在hover状态，组件被卸载，从而退出缩放

修改为在onDragStart时，自动选中节点，使组件不被卸载

close #2085