### PR TITLE
fix(docs): 修复文档中快速上手vue示例及相关文章错别字

### DIFF
--- a/sites/docs/docs/article/lowcode-with-logicflow.zh.md
+++ b/sites/docs/docs/article/lowcode-with-logicflow.zh.md
@@ -102,7 +102,7 @@ toc: content
 
 ![23-edge-code](https://github.com/didi/LogicFlow/assets/27529822/499ad962-599c-48e9-8059-cd1bee596dd2)
 
-默认情况下，LogicFlow 的文本是 svg 元素，所以当我们需要在这上面提供更多的 html 内容是，可以利用 LogicFlow 的基于**继承重写的自定义机制**，重新实现文本。上面的代码示例就是通过重写 getText 方法，利用在 svg 中插入 **foreignObject** 的方式，实现 svg 内部嵌套 html 内容。
+默认情况下，LogicFlow 的文本是 svg 元素，所以当我们需要在这上面提供更多的 html 内容时，可以利用 LogicFlow 的基于**继承重写的自定义机制**，重新实现文本。上面的代码示例就是通过重写 getText 方法，利用在 svg 中插入 **foreignObject** 的方式，实现 svg 内部嵌套 html 内容。
 
 ### 执行器
 

--- a/sites/docs/docs/tutorial/get-started.zh.md
+++ b/sites/docs/docs/tutorial/get-started.zh.md
@@ -279,13 +279,13 @@ export default function App() {
           ],
         }
       }
-    }
+    },
     mounted() {
       this.lf = new LogicFlow({
         container: this.$refs.container,
         grid: true,
       });
-      this.lf.render(renderData);
+      this.lf.render(this.renderData);
     },
   };
 </script>


### PR DESCRIPTION
在使用 LogicFlow时，我发现基础教程中的实例文档中存在着一些问题
