### PR TITLE
fix(docs): 文档api主题anchorLine描述错误问题

### DIFF
--- a/sites/docs/docs/api/theme.en.md
+++ b/sites/docs/docs/api/theme.en.md
@@ -300,7 +300,7 @@ lf.setTheme({
 
 ### anchorLine
 
-In the connecting line is, the straight line style dragged from the anchor point.
+In the connecting line, the straight line style dragged from the anchor point.
 
 ```tsx | pure
 lf.setTheme({

--- a/sites/docs/docs/api/theme.zh.md
+++ b/sites/docs/docs/api/theme.zh.md
@@ -297,7 +297,7 @@ lf.setTheme({
 
 ### anchorLine
 
-在连线是，从锚点拖出的直线样式
+在连线时，从锚点拖出的直线样式
 
 ```tsx | pure
 lf.setTheme({


### PR DESCRIPTION
修复文档中anchorLine描述错误问题
![image](https://github.com/user-attachments/assets/3f811d5c-cf6c-4de4-8762-3482e635c7c5)
