### PR TITLE
fix: delete console.log

### DIFF
--- a/packages/react-node-registry/src/model.ts
+++ b/packages/react-node-registry/src/model.ts
@@ -20,7 +20,6 @@ export class ReactNodeModel<
   P extends ReactCustomProperties = ReactCustomProperties,
 > extends HtmlNodeModel<P> {
   setAttributes() {
-    console.log('this.properties', this.properties)
     const { width, height, radius } = this.properties
     if (width) {
       this.width = width


### PR DESCRIPTION
删除了 react model 中 setAttributes 时打印的 this.properties

需要可以自行打印，打印太多污染控制台了