### PR TITLE
fix: 修复批量框选后，调整边起终点报错的 bug。

### DIFF
--- a/examples/feature-examples/src/pages/extensions/selection-select/index.tsx
+++ b/examples/feature-examples/src/pages/extensions/selection-select/index.tsx
@@ -42,6 +42,7 @@ const config: Partial<LogicFlow.Options> = {
   },
   allowRotate: true,
   allowResize: true,
+  adjustEdgeStartAndEnd: true, // 调整边的起点和终点
 }
 
 const data = {

--- a/packages/core/src/model/GraphModel.ts
+++ b/packages/core/src/model/GraphModel.ts
@@ -984,6 +984,8 @@ export class GraphModel {
     }
     if (edgeOriginData.id && this.edgesMap[edgeOriginData.id]) {
       delete edgeOriginData.id
+      delete edgeOriginData.sourceAnchorId
+      delete edgeOriginData.targetAnchorId
     }
     const Model = this.getModel(type) as BaseEdgeModelCtor
     if (!Model) {


### PR DESCRIPTION
 - 问题原因，复制粘贴后，新边的 sourceAnchorId 和 targetAnchorId 没有更新，导致开始调整时代码就报错。