### PR TITLE
fix: clearData函数内使用renderRawData替代render以绕开自定义Adapter插件的adapterIn方法

### DIFF
--- a/packages/core/src/LogicFlow.tsx
+++ b/packages/core/src/LogicFlow.tsx
@@ -1085,7 +1085,8 @@ export class LogicFlow {
   clearData() {
     this.graphModel.clearData()
     // 强制刷新数据, 让 preact 清除对已删除节点的引用
-    this.render({})
+    // 这里使用 renderRawData 绕开可能存在的自定义的Adapter插件实现的adapterIn方法
+    this.renderRawData({})
   }
 
   /*********************************************************


### PR DESCRIPTION
如果使用Adapter插件的话，render函数会收到的的数据的类型或结构不一定和logicflow自身的重合，如果把这个空对象传给render函数，render函数再传给adapterIn函数，不能保证可以正确处理

常见的触发场景为单独调用clearData或调用destroy方法，destroy内部调用clearData

另外，sites/docs和example内都在直接调用render({})，不知是否需要修改，以及adapterIn函数文档是否需要提及一下这个隐患