### PR TITLE
feat: 修改小地图 lf 实例的创建与销毁时机(#2261)

### DIFF
--- a/packages/extension/src/components/mini-map/index.ts
+++ b/packages/extension/src/components/mini-map/index.ts
@@ -198,8 +198,6 @@ export class MiniMap {
     this.bounds = boundsInit
     this.elementAreaBounds = boundsInit
     this.viewPortBounds = boundsInit
-    this.initMiniMap()
-    lf.on('graph:resize', this.onGraphResize)
   }
 
   onGraphResize = () => {
@@ -230,8 +228,10 @@ export class MiniMap {
    */
   public show = (left?: number, top?: number) => {
     if (!this.isShow) {
+      this.initMiniMap()
+      this.lf.on('graph:resize', this.onGraphResize)
       this.createMiniMap(left, top)
-      this.setView()
+      this.setView(true)
     }
     this.isShow = true
   }
@@ -240,6 +240,14 @@ export class MiniMap {
    */
   public hide = () => {
     if (this.isShow) {
+      // 隐藏小地图时摧毁实例
+      destroyTeleportContainer(this.lfMap.graphModel.flowId)
+      this.lf.off('graph:resize', this.onGraphResize)
+      this.lfMap.destroy()
+      // 保证重新创建实例时，小地图中内容偏移正确
+      this.translateX = 0
+      this.translateY = 0
+
       this.removeMiniMap()
       this.lf.emit('miniMap:close', {})
     }
@@ -677,6 +685,7 @@ export class MiniMap {
       },
     })
   }
+
   destroy() {
     destroyTeleportContainer(this.lfMap.graphModel.flowId)
     this.lf.off('graph:resize', this.onGraphResize)


### PR DESCRIPTION
- 在 show 时创建 lf 实例，在 hide 时销毁 lf 实例，这样 hide 时就不会有 lf 实例的 container 没挂载的控制台警告了

用 feature-example 里的 mini-map 实例测试过，应该没什么问题。看好像后面有加了些兼容 vue 组件的，这块没测试会不会有影响 🤔