### PR TITLE
fix: 修复通过自定义锚点实现删除节点时，props为null导致的报错问题

### DIFF
--- a/packages/core/src/view/node/BaseNode.tsx
+++ b/packages/core/src/view/node/BaseNode.tsx
@@ -88,9 +88,9 @@ export abstract class BaseNode<P extends IProps = IProps> extends Component<
     }
   }
 
-  componentDidMount() {}
+  componentDidMount() { }
 
-  componentDidUpdate() {}
+  componentDidUpdate() { }
 
   abstract getShape(): h.JSX.Element | null
 
@@ -440,6 +440,8 @@ export abstract class BaseNode<P extends IProps = IProps> extends Component<
   }
 
   handleBlur = () => {
+    // 当节点通过自定义锚点实现节点删除时，这里props会变成undefined，需兼容一下
+    if (!this.props) return
     const { model, graphModel } = this.props
     graphModel.eventCenter.emit(EventType.NODE_BLUR, {
       data: model.getData(),


### PR DESCRIPTION
版本信息："@logicflow/core": "2.0.10",

<img width="1010" height="672" alt="image" src="https://github.com/user-attachments/assets/cbc65472-ab55-4a7a-8e1d-4188cd3316d8" />
<img width="1440" height="764" alt="image" src="https://github.com/user-attachments/assets/d20e5a19-df8d-42d5-8814-f0375ecbed76" />
<img width="1440" height="764" alt="image" src="https://github.com/user-attachments/assets/fe7db605-8e1e-4142-bb24-0fc2ae61a466" />
