### PR TITLE
feat: 支持用户自定义锚点连接,提供配置来禁用拖动锚点到节点中会不断触发校验规则,插入节点时自动找到最近锚点连接

### DIFF
--- a/packages/core/src/model/EditConfigModel.ts
+++ b/packages/core/src/model/EditConfigModel.ts
@@ -126,7 +126,7 @@ export interface IEditConfigType {
   // 开启网格对齐
   snapGrid: boolean
   isPinching: boolean
-  anchorOnlyConnectValidate: boolean
+  anchorProximityValidate: boolean
 }
 
 export type IConfigKeys = keyof IEditConfigType
@@ -189,7 +189,7 @@ const allKeys = [
   'nodeTextVertical', // 节点文本是否纵向显示
   'edgeTextVertical', // 边文本是否纵向显示
   'isPinching', //是否是双指捏合态
-  'anchorOnlyConnectValidate', // 仅在靠近锚点时触发连接校验
+  'anchorProximityValidate', // 仅在靠近锚点时触发连接校验
 ] as const
 
 /**
@@ -225,7 +225,7 @@ export class EditConfigModel {
   @observable edgeTextDraggable = false
   @observable edgeTextMultiple = false // 是否支持多个边文本
   @observable edgeTextVertical = false // 边文本朝向是否是纵向
-  @observable anchorOnlyConnectValidate = false // 仅在靠近锚点时触发连接校验
+  @observable anchorProximityValidate = false // 仅在靠近锚点时触发连接校验
   /*********************************************************
    * 节点相关配置
    ********************************************************/

--- a/packages/core/src/model/GraphModel.ts
+++ b/packages/core/src/model/GraphModel.ts
@@ -89,6 +89,8 @@ export class GraphModel {
   idGenerator?: (type?: string) => string | undefined
   // 节点间连线、连线变更时的边的生成规则
   edgeGenerator: LFOptions.Definition['edgeGenerator']
+  // 自定义目标锚点连接规则
+  customTargetAnchor?: LFOptions.Definition['customTargetAnchor']
 
   // Remind：用于记录当前画布上所有节点和边的 model 的 Map
   // 现在的处理方式，用 this.nodes.map 生成的方式，如果在 new Model 的过程中依赖于其它节点的 model，会出现找不到的情况
@@ -163,6 +165,7 @@ export class GraphModel {
       edgeGenerator,
       animation,
       customTrajectory,
+      customTargetAnchor,
     } = options
     this.rootEl = container
     this.partial = !!partial
@@ -216,6 +219,7 @@ export class GraphModel {
     this.idGenerator = idGenerator
     this.edgeGenerator = createEdgeGenerator(this, edgeGenerator)
     this.customTrajectory = customTrajectory
+    this.customTargetAnchor = customTargetAnchor
   }
 
   @computed get nodesMap(): GraphModel.NodesMapType {

--- a/packages/core/src/model/edge/BaseEdgeModel.ts
+++ b/packages/core/src/model/edge/BaseEdgeModel.ts
@@ -54,18 +54,6 @@ export class BaseEdgeModel<P extends PropertiesType = PropertiesType>
 {
   readonly BaseType = ElementType.EDGE
   static BaseType: ElementType = ElementType.EDGE
-  static preferredTargetAnchorIdMap: Map<string, string> = new Map()
-  static setTargetAnchorId(nodeId: string, anchorId?: string) {
-    if (anchorId) {
-      this.preferredTargetAnchorIdMap.set(nodeId, anchorId)
-    } else {
-      this.preferredTargetAnchorIdMap.delete(nodeId)
-    }
-  }
-
-  static getTargetAnchorId(nodeId: string) {
-    return this.preferredTargetAnchorIdMap.get(nodeId)
-  }
 
   // 数据属性
   public id = ''

--- a/packages/core/src/model/node/BaseNodeModel.ts
+++ b/packages/core/src/model/node/BaseNodeModel.ts
@@ -8,7 +8,7 @@ import {
   isUndefined,
   set,
 } from 'lodash-es'
-import { GraphModel, Model, BaseEdgeModel } from '..'
+import { GraphModel, Model } from '..'
 import LogicFlow from '../../LogicFlow'
 import {
   createUuid,
@@ -150,11 +150,7 @@ export class BaseNodeModel<P extends PropertiesType = PropertiesType>
   moveRules: Model.NodeMoveRule[] = [] // 节点移动之前的hook
   resizeRules: Model.NodeResizeRule[] = [] // 节点resize之前的hook
   hasSetTargetRules = false // 用来限制rules的重复值
-  hasSetSourceRules = false // 用来限制rules的重复值
-  customTargetAnchor?: (
-    position: Point,
-    nodeModel: BaseNodeModel,
-  ) => Model.AnchorInfo | undefined;
+  hasSetSourceRules = false; // 用来限制rules的重复值
   [propName: string]: any // 支持用户自定义属性
 
   constructor(data: NodeConfig<P>, graphModel: GraphModel) {
@@ -639,20 +635,10 @@ export class BaseNodeModel<P extends PropertiesType = PropertiesType>
    * 手动连接边到节点时，需要连接的锚点
    */
   public getTargetAnchor(position: Point): Model.AnchorInfo {
-    if (typeof this.customTargetAnchor === 'function') {
-      const info = this.customTargetAnchor(position, this)
-      if (info) return info
-    }
-    const preferredId = BaseEdgeModel.getTargetAnchorId(this.id)
-    if (preferredId) {
-      const anchors = this.getAnchorsByOffset()
-      console.log(anchors)
-      const idx = anchors.findIndex((a) => a.id == preferredId)
-      if (idx >= 0) {
-        return { index: idx, anchor: anchors[idx] }
-      }
-    }
-    return getClosestAnchor(position, this)
+    const { customTargetAnchor } = this.graphModel
+    return (
+      customTargetAnchor?.(this, position) ?? getClosestAnchor(position, this)
+    )
   }
 
   /**

--- a/packages/core/src/options.ts
+++ b/packages/core/src/options.ts
@@ -1,4 +1,4 @@
-import type { TransformModel } from './model'
+import type { TransformModel, BaseNodeModel, Model } from './model'
 
 import { assign } from 'lodash-es'
 import { createElement as h } from 'preact/compat'
@@ -41,6 +41,10 @@ export namespace Options {
     currentEdge?: Partial<LogicFlow.EdgeConfig>,
   ) => any
 
+  export type customTargetAnchorType = (
+    nodeModel: BaseNodeModel,
+    position: LogicFlow.Point,
+  ) => Model.AnchorInfo | undefined
   export interface CustomAnchorLineProps {
     sourcePoint: LogicFlow.Point
     targetPoint: LogicFlow.Point
@@ -104,6 +108,7 @@ export namespace Options {
     idGenerator?: (type?: string) => string
     edgeGenerator?: EdgeGeneratorType
 
+    customTargetAnchor?: customTargetAnchorType
     customTrajectory?: (props: CustomAnchorLineProps) => h.JSX.Element
     themeMode?: 'radius' | 'dark' | 'colorful' // 主题模式
 

--- a/packages/core/src/view/Anchor.tsx
+++ b/packages/core/src/view/Anchor.tsx
@@ -314,18 +314,13 @@ class Anchor extends Component<IProps, IState> {
         return
       }
       this.preTargetNode = targetNode
-      const d = distance(endX, endY, info.anchor.x, info.anchor.y)
+      const anchorDist = distance(endX, endY, info.anchor.x, info.anchor.y)
       const validateDistance = 10
       const { editConfigModel } = graphModel
-      if (editConfigModel.anchorOnlyConnectValidate && d <= validateDistance) {
-        this.validateAndSetState(
-          targetNode,
-          anchorId,
-          info.anchor,
-          nodeModel,
-          anchorData,
-        )
-      } else if (!editConfigModel.anchorOnlyConnectValidate) {
+      if (
+        !editConfigModel.anchorProximityValidate ||
+        anchorDist <= validateDistance
+      ) {
         this.validateAndSetState(
           targetNode,
           anchorId,
@@ -364,6 +359,7 @@ class Anchor extends Component<IProps, IState> {
     }
   }
 
+  // 校验 source/target 连接规则并设置目标节点状态
   validateAndSetState(
     targetNode: BaseNodeModel,
     anchorId: string | undefined,
@@ -373,6 +369,7 @@ class Anchor extends Component<IProps, IState> {
   ) {
     const targetInfoId = `${nodeModel.id}_${targetNode.id}_${anchorId}_${anchorData.id}`
     if (!this.targetRuleResults.has(targetInfoId)) {
+      // 首次计算并缓存源/目标两侧的规则校验结果
       const sourceRuleResult = nodeModel.isAllowConnectedAsSource(
         targetNode,
         anchorData,
@@ -392,10 +389,12 @@ class Anchor extends Component<IProps, IState> {
         formatAnchorConnectValidateData(targetRuleResult),
       )
     }
+    // 读取缓存的校验结果
     const { isAllPass: isSourcePass } =
       this.sourceRuleResults.get(targetInfoId) ?? {}
     const { isAllPass: isTargetPass } =
       this.targetRuleResults.get(targetInfoId) ?? {}
+    // 两侧都通过则允许连接，否则标记为不允许连接
     if (isSourcePass && isTargetPass) {
       targetNode.setElementState(ElementState.ALLOW_CONNECT)
     } else {

--- a/packages/extension/src/insert-node-in-polyline/index.ts
+++ b/packages/extension/src/insert-node-in-polyline/index.ts
@@ -141,28 +141,32 @@ export class InsertNodeInPolyline {
           targetAnchorId!,
           nodeData,
         )
-        const startAnchorInfo = getClosestAnchor(
+        // 基于插入节点的进入交点计算出最近的“进入锚点”，用于重连原边的前半段
+        const entryAnchorInfo = getClosestAnchor(
           crossPoints.startCrossPoint,
           nodeModel,
         )
-        const startAnchor = startAnchorInfo.anchor
+        const entryAnchor = entryAnchorInfo.anchor
+        // 构造第一条边：原 source → 插入节点（终点为进入锚点）
         this._lf.addEdge({
           type,
           sourceNodeId,
           targetNodeId: nodeData.id,
           startPoint,
-          endPoint: startAnchor,
+          endPoint: entryAnchor,
         })
-        const endAnchorInfo = getClosestAnchor(
+        // 基于插入节点的离开交点计算出最近的“离开锚点”，用于重连原边的后半段
+        const exitAnchorInfo = getClosestAnchor(
           crossPoints.endCrossPoint,
           nodeModel,
         )
-        const endAnchor = endAnchorInfo.anchor
+        const exitAnchor = exitAnchorInfo.anchor
+        // 构造第二条边：插入节点 → 原 target（起点为离开锚点）
         this._lf.addEdge({
           type,
           sourceNodeId: nodeData.id,
           targetNodeId,
-          startPoint: cloneDeep(endAnchor),
+          startPoint: cloneDeep(exitAnchor),
           endPoint: cloneDeep(pointsList[pointsList.length - 1]),
         })
         if (!checkResult.isPass) {


### PR DESCRIPTION
1. fix:https://github.com/didi/LogicFlow/issues/810
**解决方案:** 提供**anchorOnlyConnectValidate**配置，默认值为false。当设置为true时，禁用拖动锚点到节点中会不断触发校验规则的现象，变成只有拖动到锚点附近时才会触发校验规则。具体使用如下
`lf.updateEditConfig({ anchorProximityValidate: true })  // 默认值为false`
2. fix:https://github.com/didi/LogicFlow/issues/791
**解决方案:** 支持用户自定义锚点连接指向，提供customTargetAnchor方法，在new LogicFlow时传入，使用方法类比于edge Generator，当**customTargetAnchor不返回值或者返回undefined时**，采用默认锚点连接规则**（连接最近锚点）**。示例如下：
  - 根据节点id来指定某一个节点的锚点连接规则：
```
        customTargetAnchor(nodeModel, position) {
          const anchors = nodeModel.anchors
          if (nodeModel.id === '2') {
            const targetId = '2_3'
            const idx = anchors.findIndex((a) => a.id === targetId)
            const finalIdx = idx >= 0 ? idx : 0
            return { index: finalIdx, anchor: anchors[finalIdx] }
          }
        },
```
   - 也可以修改全局的锚点连接规则
 
```
        customTargetAnchor: (nodeModel, position) => {
          const anchors = nodeModel.getAnchorsByOffset()
          let idx = 0
          // 找到最左侧锚点
          for (let i = 1; i < anchors.length; i++) {
            if (anchors[i].x < anchors[idx].x) idx = i
          }
          return { index: idx, anchor: anchors[idx] }
       }
```
3. https://github.com/didi/LogicFlow/issues/723
**解决方案:** 当插入节点时，**允许一定误差**，节点锚点没有严格对齐连线也可以插入进连线里，并且会**连接到最近的锚点**。