### PR TITLE
Use key over text in Control Extension

### DIFF
--- a/packages/extension/src/components/control/index.ts
+++ b/packages/extension/src/components/control/index.ts
@@ -130,13 +130,13 @@ export class Control {
       } else {
         itemContainer.append(icon)
       }
-      switch (item.text) {
-        case '上一步':
+      switch (item.key) {
+        case 'undo':
           this.lf.on('history:change', ({ data: { undoAble } }: any) => {
             itemContainer.className = undoAble ? NORMAL : DISABLED
           })
           break
-        case '下一步':
+        case 'redo':
           this.lf.on('history:change', ({ data: { redoAble } }: any) => {
             itemContainer.className = redoAble ? NORMAL : DISABLED
           })


### PR DESCRIPTION
Hey guys,

I'd like to use this repo but some things that I like to use are hardcoded right now. To allow translations to different languages I would suggest going from `item.text` to `item.key` in this particular place.

 I did not look too deep in this, and I am not sure if it has other side effects.