### PR TITLE
docs: 修复文档事件说明和自定义锚点报错，补充样式边示例

### DIFF
--- a/sites/docs/docs/api/eventCenter.en.md
+++ b/sites/docs/docs/api/eventCenter.en.md
@@ -34,8 +34,7 @@ flowchart. The detailed usage of events is described in [events](../tutorial/bas
 | node:drag                                      | Nodes in dragging                      | data, e                                                                                                                                           |
 | node:drop                                      | End of node dragging                   | data, e                                                                                                                                           |
 | node:contextmenu                               | Right-click on the node                | data, e, position                                                                                                                                 |
-| node:resize<Badge>2.0 Added</Badge>            | Adjust node scaling                    | preData, data, model, deltaX, deltaY, index                                                                                                       |
-| node:resize-start<Badge>2.0 Added</Badge>      | Start adjusting node scaling           | e, data, model                                                                                                                                    |
+| node:resize<Badge>2.0 Added</Badge>            | Adjust node scaling                    | preData, data, model, deltaX, deltaY, index                                                                                 |
 | node:properties-change<Badge>2.0 Added</Badge> | Node custom properties change          | id: Current node id<br/>keys: Set of keys for current changes<br/>preProperties: Properties before change<br/>properties: Properties after change |
 
 The event object contains the following:

--- a/sites/docs/docs/api/eventCenter.zh.md
+++ b/sites/docs/docs/api/eventCenter.zh.md
@@ -35,7 +35,6 @@ LogicFlow
 | node:drop                                     | 节点拖拽放开           | data, e                                                                                                                     |
 | node:contextmenu                              | 右键点击节点           | data, e, position                                                                                                           |
 | node:resize<Badge>2.0 新增</Badge>            | 调整节点缩放           | preData, data, model, deltaX, deltaY, index                                                                                 |
-| node:resize<Badge>2.0 新增</Badge>            | 调整节点缩放           | e, data, model                                                                                                              |
 | node:properties-change<Badge>2.0 新增</Badge> | 节点自定义属性变化     | id: 当前节点的id<br/>keys: 当前变更字段的key的集合<br/>preProperties: 改动前的properties<br/>properties: 改动后的properties |
 
 事件对象包含如下内容：

--- a/sites/docs/docs/tutorial/basic/edge.en.md
+++ b/sites/docs/docs/tutorial/basic/edge.en.md
@@ -42,7 +42,14 @@ You just need to customize the style class in [edgeModel](../../api/edgeModel.en
 :::info{title=提示}
 Custom edges also need to be registered using `register`.
 :::
+## Modify edge style
+Similar to node style attributes, edge styles can also be customized via [theme configuration](../../api/theme.en.md). The edge style is then redefined by this.
 
+- If you need to define styles according to the state of the edge, you can put the passed parameters into `properties`, and in `getEdgeStyle`, you can judge the parameters in `properties` and return different styles according to different parameters.
+- To achieve the hover effect, you can listen for the `edge:mouseenter` and `edge:mouseleave` events, modify the parameters in `properties`, and then call the `edge.updateStyle()` method to update the edge style.
+- It is not recommended to use the `setStyle` method to set the style of the edges. This method is generally used to skip the rendering of custom edges when developing plugins.
+
+<code id="edge-style" src="../../../src/tutorial/basic/edge/style"></code>
 ## Customize side text position
 
 By default, the position of the text on the edge is the position when the user double-clicks on the

--- a/sites/docs/docs/tutorial/basic/edge.zh.md
+++ b/sites/docs/docs/tutorial/basic/edge.zh.md
@@ -40,7 +40,14 @@ import { BezierEdge, BezierEdgeModel } from '@logicflow/core'
 :::info{title=提示}
 自定义边同样需要使用`register`注册哦。
 :::
+## 修改边样式
+和节点的样式属性一样边样式也支持通过 [主题配置](../../api/theme.zh.md) 自定义边的样式则是它重新定义。
 
+- 如果需要按照边的状态定义样式，可以把传递的参数放入`properties`中，在`getEdgeStyle`中判断`properties`中的参数，根据不同的参数返回不同的样式。
+- 如果需要实现hover的效果，可以监听`edge:mouseenter`和`edge:mouseleave`事件，修改完`properties`中的参数，然后调用`edge.updateStyle()`方法更新边的样式。
+- 不建议使用`setStyle`方法设置边的样式,这个方法一般用于插件开发时跳过自定义边的渲染。
+
+<code id="edge-style" src="../../../src/tutorial/basic/edge/style"></code>
 ## 自定义边文本位置
 
 默认情况下，边上文本的位置是用户双击点击边时的位置。如果是通过 API 的方式给边添加的文本，文本位置按照如下规则。

--- a/sites/docs/docs/tutorial/update.en.md
+++ b/sites/docs/docs/tutorial/update.en.md
@@ -154,7 +154,7 @@ Fixed the bug that TextEditTool is invalid, and the reason is noted later
 **Optimization**
 In version 1.x, the node scaling capability needs to be implemented by introducing the NodeResize plug-in. In version 2.0, we built the resize capability into the basic node; and also supported the configurable node rotation capability.
 1. Users can set whether all nodes in the current instance are scalable and rotatable through the global configuration items `allowResize` and `allowRotate`;
-2. You can also add `resizable` and `rotatable` parameters in the `properties` of the initial rendering incoming data to control whether a single node is rotatable and scalable. Internally, the node's `resizable` and `rotatable` default to `true`;
+2. You can also add `resizable` and `rotatable` parameters in the `properties` of the initial rendering incoming data to control whether a single node is rotatable and scalable(This will only take effect if `allowResize`/`allowRotate` is set to true globally.). Internally, the node's `resizable` and `rotatable` default to `true`;
 
 :::warning{title=Tip}
 After the scaling capability is built-in, the NodeResize plug-in will be gradually abandoned

--- a/sites/docs/docs/tutorial/update.zh.md
+++ b/sites/docs/docs/tutorial/update.zh.md
@@ -130,7 +130,7 @@ y2 → maxY
 ### Extension
 
 #### 框选插件
-**新能力s**
+**新能力**
 1. 增加`selection:selected-area`事件，返回框选范围;
 2. 框选插件默认启用状态改为不启用，如需初始化时就启用框选，在LogicFlow实例创建后调用`lf.extension.selectionSelect.open()`方法开启框选;
 **问题修复**
@@ -138,7 +138,7 @@ y2 → maxY
 2. 修复缩放后，框选边距与外边框宽度计算问题;
 
 #### 小地图插件
-**新能力s**
+**新能力**
 1. 支持配置小地图展示位置;
 2. 支持选择是否渲染连线，支持初始化时设置或通过`setShowEdge`方法更新设置;
 3. 小地图显示内容优化，目前会有画布元素与视口位置共同决定展示内容;
@@ -153,7 +153,7 @@ y2 → maxY
 **优化**
 在1.x版本中，节点缩放能力需要通过引入NodeResize插件实现，在2.0版本中，我们将resize能力内置到基础节点上;同时还支持了节点旋转能力可配置。
 1. 用户可以通过全局配置项`allowResize`、`allowRotate`设置当前实例中所有节点是否可缩放、可旋转;
-2. 也可以在初始化渲染传入数据的`properties`中增加`resizable`、`rotatable`参数控制单个节点是否可旋转可缩放，在内部，节点的`resizable`和`rotatable`默认为`true`;
+2. 也可以在初始化渲染传入数据的`properties`中增加`resizable`（需要全局配置`allowResize`为true才会生效）、`rotatable`参数控制单个节点是否可旋转可缩放（需要全局配置`allowRotate`为true才会生效），在内部，节点的`resizable`和`rotatable`默认为`true`;
 
 :::warning{title=Tip}
   缩放能力内置后，NodeResize插件会逐步废弃
@@ -176,7 +176,7 @@ y2 → maxY
 
 #### Group插件
 在2.0版本里，我们重写了分组插件相关逻辑，将 Group 插件升级为 [Dynamic Group 插件](extension/dynamic-group.zh.md)
-**新能力s**
+**新能力**
 1. 支持分组节点缩放旋转时，内部元素也随之同步缩放旋转;
 
 **优化**
@@ -184,7 +184,7 @@ y2 → maxY
 2. 优化允许文本拖动的逻辑判断 -> nodeTextDraggable && draggable 才可以允许拖动;
 
 #### HighLight插件
-**新能力s**
+**新能力**
 1. 支持高亮邻居节点模式;
 2. 支持外部传参配置高亮形式;
 
@@ -192,7 +192,7 @@ y2 → maxY
 1. 补充功能介绍文档[HighLight 插件](extension/highlight.zh.md)
 
 #### 「New」Label插件
-**新能力s**
+**新能力**
 在2.0版本里，我们新增了一种文本展现形式：Label，这种形式与现有Text形式文本之间的主要区别点在于：
 1. 支持一个节点/一条边 上可以添加多个文本，且可以设置文本朝向;
 2. 自带富文本编辑能力，支持设置局部文本样式;

--- a/sites/docs/src/tutorial/advanced/node/sql/sqlNode.ts
+++ b/sites/docs/src/tutorial/advanced/node/sql/sqlNode.ts
@@ -74,7 +74,6 @@ class SqlNodeModel extends HtmlNodeModel {
   getOutlineStyle() {
     const style = super.getOutlineStyle();
     style.stroke = 'none';
-    style.hover.stroke = 'none';
     return style;
   }
 
@@ -83,8 +82,6 @@ class SqlNodeModel extends HtmlNodeModel {
     const style = super.getAnchorStyle();
     if (anchorInfo.type === 'left') {
       style.fill = 'red';
-      style.hover.fill = 'transparent';
-      style.hover.stroke = 'transpanrent';
       style.className = 'lf-hide-default';
     } else {
       style.fill = 'green';

--- a/sites/docs/src/tutorial/basic/edge/style/hoverEdge.ts
+++ b/sites/docs/src/tutorial/basic/edge/style/hoverEdge.ts
@@ -1,0 +1,35 @@
+import { PolylineEdge, PolylineEdgeModel } from '@logicflow/core';
+
+export class PropertyHoverEdgeModel extends PolylineEdgeModel {
+  initEdgeData(data: any) {
+    super.initEdgeData(data);
+    // 初始化 hover 状态
+    this.properties.isHover = false;
+  }
+
+  // 这个方法可以在需要时读取
+  getEdgeStyle() {
+    const style = super.getEdgeStyle();
+    const { isHover } = this.properties;
+
+    if (isHover) {
+      return {
+        ...style,
+        stroke: '#ff4d4f',
+        strokeWidth: 3,
+      };
+    }
+
+    return {
+      ...style,
+      stroke: '#999',
+      strokeWidth: 5,
+    };
+  }
+}
+
+export const HoverEdge = {
+  type: 'hover-edge',
+  view: PolylineEdge,
+  model: PropertyHoverEdgeModel,
+};

--- a/sites/docs/src/tutorial/basic/edge/style/index.tsx
+++ b/sites/docs/src/tutorial/basic/edge/style/index.tsx
@@ -1,0 +1,130 @@
+import React, { useEffect, useRef, useState } from 'react';
+import LogicFlow from '@logicflow/core';
+import '@logicflow/core/dist/index.css';
+import StatusButtons from './statusButton';
+import { StatusEdge } from './statusEdge';
+import { HoverEdge } from './hoverEdge';
+const SilentConfig = {
+  stopScrollGraph: true,
+  stopMoveGraph: true,
+  stopZoomGraph: true,
+};
+const App: React.FC = () => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [lf, setLf] = useState<LogicFlow | null>(null);
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+
+    const lfInstance = new LogicFlow({
+      container: containerRef.current,
+      grid: true,
+      ...SilentConfig,
+    });
+    lfInstance.register(StatusEdge);
+    lfInstance.register(HoverEdge);
+    lfInstance.render({
+      nodes: [
+        {
+          id: 'n1',
+          type: 'rect',
+          x: 100,
+          y: 200,
+        },
+        {
+          id: 'n2',
+          type: 'rect',
+          x: 500,
+          y: 200,
+        },
+        {
+          id: 'n3',
+          type: 'rect',
+          x: 100,
+          y: 300,
+        },
+        {
+          id: 'n4',
+          type: 'rect',
+          x: 500,
+          y: 300,
+        },
+        {
+          id: 'n5',
+          type: 'rect',
+          x: 100,
+          y: 400,
+        },
+        {
+          id: 'n6',
+          type: 'rect',
+          x: 500,
+          y: 400,
+        },
+      ],
+      edges: [
+        {
+          id: 'e1',
+          type: 'status-edge',
+          sourceNodeId: 'n1',
+          targetNodeId: 'n2',
+          text: '根据状态渲染的边颜色，先选中这条边',
+          properties: { status: 'todo' },
+        },
+        {
+          id: 'e2',
+          type: 'polyline',
+          text: '内置样式边',
+          sourceNodeId: 'n3',
+          targetNodeId: 'n4',
+        },
+        {
+          id: 'e3',
+          type: 'hover-edge',
+          text: '鼠标移入hover变化',
+          sourceNodeId: 'n5',
+          targetNodeId: 'n6',
+        },
+      ],
+    });
+    lfInstance.translateCenter();
+    //直接调用model修改style样式 但是不支持 因为属于直接越权操作了 建议还是继承getEdgeStyle方法
+    const edgeModel = lfInstance.graphModel.getEdgeModelById('e2');
+    edgeModel?.setStyles({
+      stroke: '#722ed1',
+      strokeWidth: 2,
+      strokeDasharray: '5 5',
+    });
+
+    setLf(lfInstance);
+  }, []);
+  lf?.on('edge:mouseenter', ({ data }) => {
+    if (data.type !== 'hover-edge') {
+      return;
+    }
+    lf.setProperties(data.id, {
+      isHover: true,
+    });
+  });
+
+  lf?.on('edge:mouseleave', ({ data }) => {
+    if (data.type !== 'hover-edge') {
+      return;
+    }
+    lf.setProperties(data.id, {
+      isHover: false,
+    });
+  });
+
+  return (
+    <div style={{ padding: 16 }}>
+      {lf && <StatusButtons lf={lf} />}
+      <div
+        ref={containerRef}
+        style={{ height: 600, border: '1px solid #eee', marginTop: 12 }}
+      />
+    </div>
+  );
+};
+
+export default App;

--- a/sites/docs/src/tutorial/basic/edge/style/statusButton.tsx
+++ b/sites/docs/src/tutorial/basic/edge/style/statusButton.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Button, Space, message } from 'antd';
+import LogicFlow from '@logicflow/core';
+
+interface Props {
+  lf: LogicFlow;
+}
+
+const StatusButtons: React.FC<Props> = ({ lf }) => {
+  const getCurrentEdge = () => {
+    const { edges } = lf.getSelectElements();
+    return edges?.[0];
+  };
+
+  const onSetEdgeStatus = (status: 'todo' | 'done') => {
+    const edge = getCurrentEdge();
+    if (!edge) {
+      message.warning('请先选择一条边');
+      return;
+    }
+
+    // 改变边的properties
+    lf.setProperties(edge.id, { status });
+  };
+
+  return (
+    <Space>
+      <Button danger onClick={() => onSetEdgeStatus('todo')}>
+        未完成
+      </Button>
+      <Button type="primary" onClick={() => onSetEdgeStatus('done')}>
+        已完成
+      </Button>
+    </Space>
+  );
+};
+
+export default StatusButtons;

--- a/sites/docs/src/tutorial/basic/edge/style/statusEdge.ts
+++ b/sites/docs/src/tutorial/basic/edge/style/statusEdge.ts
@@ -1,0 +1,21 @@
+import { PolylineEdge, PolylineEdgeModel } from '@logicflow/core';
+
+class StatusEdgeModel extends PolylineEdgeModel {
+  getEdgeStyle() {
+    const style = super.getEdgeStyle();
+    const { status } = this.properties || {};
+    if (status === 'done') {
+      style.stroke = '#52c41a'; // 绿色
+    } else if (status === 'todo') {
+      style.stroke = '#ff4d4f'; // 红色
+    }
+    style.strokeWidth = 2;
+    return style;
+  }
+}
+
+export const StatusEdge = {
+  type: 'status-edge',
+  view: PolylineEdge,
+  model: StatusEdgeModel,
+};


### PR DESCRIPTION
1. 解决docs问题
关联issue：

- 解决node:size文档标注不全问题 https://github.com/didi/LogicFlow/issues/1825
- 补充边样式示例：https://github.com/didi/LogicFlow/issues/1611#event-22210629752
- 解决自由锚点报错部分：https://github.com/didi/LogicFlow/issues/2363

2.解决用户使用边不方便以及解决文档存在的一些bug问题