### PR TITLE
fix: 修复vue2自定义节点获取props错误

### DIFF
--- a/packages/vue-node-registry/src/view.ts
+++ b/packages/vue-node-registry/src/view.ts
@@ -96,8 +96,10 @@ export class VueNodeView extends HtmlNode {
             el: root,
             render(h: any) {
               return h(Composed, {
-                node: model,
-                graph: graphModel,
+                props: {
+                  node: model,
+                  graph: graphModel,
+                },
               })
             },
             provide() {


### PR DESCRIPTION
1. fix: https://github.com/didi/LogicFlow/issues/2346