### PR TITLE
fix: @logicflow/vue-node-registry 1.1.13版本打包没有js

### DIFF
--- a/packages/vue-node-registry/src/view.ts
+++ b/packages/vue-node-registry/src/view.ts
@@ -88,17 +88,17 @@ export class VueNodeView extends HtmlNode {
 
     if (root) {
       const nodeConfig = getVueNodeConfig(model.type, graphModel)
+      const flowId = this.props.graphModel.flowId
       if (!nodeConfig) {
         // No registered config for this node type; ensure any existing Teleport mount is cleaned up
-        const flowId = this.props.graphModel.flowId
         if (isVue3 && isActive() && flowId) {
           disconnect(this.targetId(), flowId)
         }
         return
       }
+      const { component } = nodeConfig
       if (!component) {
         // Config exists but has no component; also clean up any existing Teleport mount
-        const flowId = this.props.graphModel.flowId
         if (isVue3 && isActive() && flowId) {
           disconnect(this.targetId(), flowId)
         }


### PR DESCRIPTION
Fixes #2386 

修复 @logicflow/vue-node-registry 1.1.13版本打包没有js问题；
原因：/LogicFlow/packages/vue-node-registry/src/view.ts 中 disconnect 缺少必要参数。
<img width="1708" height="876" alt="image" src="https://github.com/user-attachments/assets/a926102a-a22e-43aa-b9ba-e5f154b524f7" />