### PR TITLE
fix(core): preserve nested control focus on node click

### DIFF
--- a/packages/core/__tests__/bugs/2406-spec.test.ts
+++ b/packages/core/__tests__/bugs/2406-spec.test.ts
@@ -1,0 +1,89 @@
+/**
+ * @jest-environment jsdom
+ */
+import { createElement as h } from 'preact/compat'
+
+import { BaseNode } from '../../src'
+
+class TestNode extends BaseNode<any> {
+  getShape() {
+    return h('g', null)
+  }
+}
+
+const createNode = () => {
+  const model = {
+    id: 'node_1',
+    isDragging: false,
+    isSelected: false,
+    autoToFront: false,
+    text: {
+      editable: false,
+    },
+    getData: jest.fn(() => ({ id: 'node_1' })),
+    setSelected: jest.fn(),
+  }
+  const graphModel = {
+    gridSize: 1,
+    eventCenter: {
+      emit: jest.fn(),
+    },
+    editConfigModel: {
+      isSilentMode: false,
+      multipleSelectKey: 'meta',
+      nodeTextEdit: false,
+      textMode: 'TEXT',
+    },
+    getPointByClient: jest.fn(() => ({
+      canvasOverlayPosition: { x: 0, y: 0 },
+      domOverlayPosition: { x: 0, y: 0 },
+    })),
+    selectNodeById: jest.fn(),
+    setElementStateById: jest.fn(),
+    toFront: jest.fn(),
+  }
+  const node = new TestNode({ model, graphModel } as any)
+  ;(node as any).props = { model, graphModel }
+  node.startTime = Date.now()
+  node.mouseUpDrag = true
+  return { node, model, graphModel }
+}
+
+describe('issue 2406', () => {
+  const originalRequestAnimationFrame = window.requestAnimationFrame
+
+  beforeEach(() => {
+    window.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+      callback(0)
+      return 0
+    }) as typeof window.requestAnimationFrame
+  })
+
+  afterEach(() => {
+    window.requestAnimationFrame = originalRequestAnimationFrame
+    jest.restoreAllMocks()
+  })
+
+  test('does not steal focus from nested form controls on node click', () => {
+    const { node } = createNode()
+    const nodeElement = document.createElement('g') as any
+    nodeElement.focus = jest.fn()
+    const input = document.createElement('input')
+    nodeElement.appendChild(input)
+
+    node.handleClick({
+      button: 0,
+      clientX: 0,
+      clientY: 0,
+      currentTarget: nodeElement,
+      target: input,
+      detail: 1,
+      metaKey: false,
+      altKey: false,
+      shiftKey: false,
+      ctrlKey: false,
+    } as any)
+
+    expect(nodeElement.focus).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/view/node/BaseNode.tsx
+++ b/packages/core/src/view/node/BaseNode.tsx
@@ -19,6 +19,9 @@ import {
 import RotateControlPoint from '../Rotate'
 import ResizeControlGroup from '../Control'
 
+const NESTED_FOCUS_CONTROL_SELECTOR =
+  'input, textarea, select, button, [contenteditable="true"], [contenteditable=""]'
+
 type IProps = {
   model: BaseNodeModel
   graphModel: GraphModel
@@ -413,9 +416,17 @@ export abstract class BaseNode<P extends IProps = IProps> extends Component<
         !isNil(window) && isFunction(window.requestAnimationFrame)
           ? window.requestAnimationFrame.bind(window)
           : (fn: () => void) => setTimeout(fn, 0)
-      rAF(() => {
-        el.focus()
-      })
+      const target = e.target as Element | null
+      const nestedFocusControl =
+        target &&
+        target !== el &&
+        isFunction(target.closest) &&
+        target.closest(NESTED_FOCUS_CONTROL_SELECTOR)
+      if (!nestedFocusControl || !el.contains(nestedFocusControl)) {
+        rAF(() => {
+          el.focus()
+        })
+      }
     }
   }
 


### PR DESCRIPTION
### Description

This change prevents node click handling from forcing focus back to the node wrapper when the original click target is a nested form/editor control.

The node still restores wrapper focus for ordinary node clicks, preserving the copy/paste focus behavior that the existing `requestAnimationFrame(...focus())` path was added for.

### Motivation and Context

Fixes didi/LogicFlow#2406.

Custom nodes can embed controls such as `input`, `select`, `textarea`, buttons, or contenteditable editors. The current `handleClick` implementation schedules `currentTarget.focus()` after every node click, so clicking one of those embedded controls can immediately move focus away from the control.

This patch skips wrapper focus only when the click target is inside one of those nested controls and adds a regression test for that path.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [x] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that add or update documentation)
- [ ] Chore (changes that do not modify src or test files)

### Self Check before Merge

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [**CONTRIBUTING**](https://github.com/didi/LogicFlow/blob/next/CONTRUBUTING.en-US.md) document
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Verification:

- `pnpm test -- packages/core/__tests__/bugs/2406-spec.test.ts --runInBand`
- `pnpm exec eslint packages/core/src/view/node/BaseNode.tsx packages/core/__tests__/bugs/2406-spec.test.ts`
- `pnpm --filter @logicflow/core run build:esm`
- `git diff --check`
