### PR TITLE
docs: fix broken star history chart in README

### DIFF
--- a/README.en-US.md
+++ b/README.en-US.md
@@ -160,11 +160,11 @@ To become a contributor, please follow our [contributing guide](/CONTRUBUTING.en
 
 ## Star History
 
-<a href="https://www.star-history.com/#didi/LogicFlow&Date">
+<a href="https://star-history.dera.page/#didi/LogicFlow&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=didi/LogicFlow&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=didi/LogicFlow&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=didi/LogicFlow&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=didi/LogicFlow&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=didi/LogicFlow&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=didi/LogicFlow&type=Date" />
  </picture>
 </a>
 

--- a/README.md
+++ b/README.md
@@ -155,11 +155,11 @@ $ cd examples/feature-examples && pnpm dev
 
 ## Star History
 
-<a href="https://www.star-history.com/#didi/LogicFlow&Date">
+<a href="https://star-history.dera.page/#didi/LogicFlow&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=didi/LogicFlow&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=didi/LogicFlow&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=didi/LogicFlow&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=didi/LogicFlow&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=didi/LogicFlow&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=didi/LogicFlow&type=Date" />
  </picture>
 </a>
 


### PR DESCRIPTION
The Star History chart on our README was broken and no longer rendering, which hides one of the best signals about project traction. This PR moves the chart and its links to a working instance of the service so the chart displays correctly again.

Updated both README.md and README.en-US.md. No functional code changes.